### PR TITLE
isx031: add IPU8 MIPI configs, BIOS guide, and placeholder entities

### DIFF
--- a/config/isx031/ipu8/libcamhal_configs.json
+++ b/config/isx031/ipu8/libcamhal_configs.json
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2026 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+{
+    "Common" : {
+        "version": 1.0,
+        "platform": "IPU7",
+        //  The value format of availableSensors is "sensor name"-wf/uf-"CSI port ID".
+        //  wf is world facing, and uf is user facing.
+        "availableSensors": ["isx031-a-0","isx031-b-2"],
+        "videoStreamNum" : 2
+    }
+}

--- a/config/isx031/ipu8/sensors/isx031-a.json
+++ b/config/isx031/ipu8/sensors/isx031-a.json
@@ -27,18 +27,18 @@
             "output": [1920, 1080],
             "format": "V4L2_PIX_FMT_UYVY",
             "formats": [
-              { "name": "isx031 1-001a", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
-              { "name": "Intel IPU7 CSI2 0", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "isx031 $I2CBUS", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 CSI2 $CSI_PORT", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
               { "name": "Intel IPU7 ISYS Capture 0", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 }
             ],
             "link": [
-              { "srcName": "isx031 1-001a", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 0", "sinkPad": 0, "enable": true },
-              { "srcName": "Intel IPU7 CSI2 0", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 0", "sinkPad": 0, "enable": true }
+              { "srcName": "isx031 $I2CBUS", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 $CSI_PORT", "sinkPad": 0, "enable": true },
+              { "srcName": "Intel IPU7 CSI2 $CSI_PORT", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 0", "sinkPad": 0, "enable": true }
             ],
             "videonode": [
               { "name": "Intel IPU7 ISYS Capture 0", "videoNodeType": "VIDEO_GENERIC" },
-              { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
-              { "name": "isx031 1-001a", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+              { "name": "Intel IPU7 CSI2 $CSI_PORT", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "isx031 $I2CBUS", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
             ]
           }
         ],

--- a/config/isx031/ipu8/sensors/isx031-a.json
+++ b/config/isx031/ipu8/sensors/isx031-a.json
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2026 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+{
+  "CameraSettings": {
+    "Sensor": [
+      {
+        "name": "isx031-a",
+        "description": "ISX031 MIPI CSI-2 Sensor 1",
+        "MediaCtlConfig": [
+          {
+            "id": 0,
+            "configMode": "AUTO",
+            "output": [1920, 1080],
+            "format": "V4L2_PIX_FMT_UYVY",
+            "formats": [
+              { "name": "isx031 1-001a", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 CSI2 0", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 ISYS Capture 0", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 }
+            ],
+            "link": [
+              { "srcName": "isx031 1-001a", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 0", "sinkPad": 0, "enable": true },
+              { "srcName": "Intel IPU7 CSI2 0", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 0", "sinkPad": 0, "enable": true }
+            ],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 0", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "isx031 1-001a", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_UYVY", "size": [1920, 1080], "field": 0, "mcId": 0 }
+          ]
+        },
+
+        "supportedISysSizes": [[1920, 1080]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_UYVY"],
+        "enableAIQ": false,
+        "usePSysProcessor": false
+      }
+    ]
+  }
+}

--- a/config/isx031/ipu8/sensors/isx031-b.json
+++ b/config/isx031/ipu8/sensors/isx031-b.json
@@ -27,18 +27,18 @@
             "output": [1920, 1080],
             "format": "V4L2_PIX_FMT_UYVY",
             "formats": [
-              { "name": "isx031 0-001a", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
-              { "name": "Intel IPU7 CSI2 2", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "isx031 $I2CBUS", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 CSI2 $CSI_PORT", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
               { "name": "Intel IPU7 ISYS Capture 16", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 }
             ],
             "link": [
-              { "srcName": "isx031 0-001a", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 2", "sinkPad": 0, "enable": true },
-              { "srcName": "Intel IPU7 CSI2 2", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 16", "sinkPad": 0, "enable": true }
+              { "srcName": "isx031 $I2CBUS", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 $CSI_PORT", "sinkPad": 0, "enable": true },
+              { "srcName": "Intel IPU7 CSI2 $CSI_PORT", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 16", "sinkPad": 0, "enable": true }
             ],
             "videonode": [
               { "name": "Intel IPU7 ISYS Capture 16", "videoNodeType": "VIDEO_GENERIC" },
-              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
-              { "name": "isx031 0-001a", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+              { "name": "Intel IPU7 CSI2 $CSI_PORT", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "isx031 $I2CBUS", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
             ]
           }
         ],

--- a/config/isx031/ipu8/sensors/isx031-b.json
+++ b/config/isx031/ipu8/sensors/isx031-b.json
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2026 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+{
+  "CameraSettings": {
+    "Sensor": [
+      {
+        "name": "isx031-b",
+        "description": "ISX031 MIPI CSI-2 Sensor 2",
+        "MediaCtlConfig": [
+          {
+            "id": 0,
+            "configMode": "AUTO",
+            "output": [1920, 1080],
+            "format": "V4L2_PIX_FMT_UYVY",
+            "formats": [
+              { "name": "isx031 0-001a", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 CSI2 2", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 },
+              { "name": "Intel IPU7 ISYS Capture 16", "pad": 0, "width": 1920, "height": 1080, "format": "V4L2_MBUS_FMT_UYVY8_1X16", "stream": 0 }
+            ],
+            "link": [
+              { "srcName": "isx031 0-001a", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 2", "sinkPad": 0, "enable": true },
+              { "srcName": "Intel IPU7 CSI2 2", "srcPad": 1, "sinkName": "Intel IPU7 ISYS Capture 16", "sinkPad": 0, "enable": true }
+            ],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 16", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "isx031 0-001a", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_UYVY", "size": [1920, 1080], "field": 0, "mcId": 0 }
+          ]
+        },
+
+        "supportedISysSizes": [[1920, 1080]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_UYVY"],
+        "enableAIQ": false,
+        "usePSysProcessor": false
+      }
+    ]
+  }
+}

--- a/doc/isx031/userspace-mipi.md
+++ b/doc/isx031/userspace-mipi.md
@@ -163,6 +163,60 @@ Config path: `Intel Advanced Menu`->`System Agent (SA) Configuration`->`MIPI Cam
 | Customize Device ID Number | 19                   | 19                   |
 | Flash Driver Selection     | Disabled             | Disabled             |
 
+### MIPI Camera Configuration for IPU8 (NVL)
+
+Config path: `Intel Advanced Menu`->`System Agent (SA) Configuration`->`MIPI Camera Configuration`
+
+**Note:** For CRD2, we need to use a Samtec cable to connect the second MIPI camera.
+
+|                            | Control Logic 1      | Control Logic 2      |
+|---                         |---                   |---                   |
+| Control Logic Type         | Discrete             | Discrete             |
+| CRD Version                | CRD-D                | CRD-D                |
+| Input Clock                | 19.2MHz              | 19.2MHz              |
+| PCH Clock                  | IMGCLKOUT_0          | IMGCLKOUT_1          |
+| Number of GPIOs            | 1                    | 1                    |
+| GPIO Pin 0                 |                      |                      |
+| Group Pad Number           | 10                   | 1                    |
+| Group Number               | C_E_V                | C_E_V                |
+| Com Number                 | COM1                 | COM1                 |
+| Function                   | RESET                | RESET                |
+| Active Value               | 1                    | 1                    |
+| Initial Value              | 0                    | 0                    |
+
+|                            | Camera1 Link options | Camera2 Link options |
+|---                         |---                   |---                   |
+| Sensor Model               | Custom Display Bridge| Custom Display Bridge|
+| Audio HID                  | _                    | _                    |
+| Custom HID                 | INTC113C             | INTC113C             |
+| Lanes Clock division       | 4 4 2 2              | 4 4 2 2              |
+| CRD Version                | CRD-D                | CRD-D                |
+| GPIO control               | Control Logic 1      | Control Logic 2      |
+| Camera position            | Front                | Back                 |
+| Flash Support              | Disabled             | Disabled             |
+| Privacy LED                | Driver default       | Driver default       |
+| Rotation                   | 0                    | 0                    |
+| Voltage Rail               |                      | 3 voltage rail       |
+| PPR Value                  | 0                    | 0                    |
+| PPR Unit                   | 0                    | 0                    |
+| PhyConfiguration           | DPHY                 | DPHY                 |
+| Camera module name         | _                    | _                    |
+| MIPI port                  | 0                    | 2                    |
+| LaneUsed                   | x4                   | x2                   |
+| MCLK                       | 19200000             | 19200000             |
+| EEPROM Type                | ROM_NONE             | ROM_NONE             |
+| VCM Type                   | VCM_NONE             | VCM_NONE             |
+| Number of I2C Components   | 1                    | 1                    |
+| I2C Channel                | I2C1                 | I2C0                 |
+| Device 0                   |                      |                      |
+| I2C Address                | 1A                   | 1A                   |
+| Device Type                | Sensor               | Sensor               |
+| Customize Device ID List   |                      |                      |
+| Customize Device ID Number | 17                   | 17                   |
+| Customize Device ID Number | 18                   | 18                   |
+| Customize Device ID Number | 19                   | 19                   |
+| Flash Driver Selection     | Disabled             | Disabled             |
+
 > **Note:** CPHY-DPHY adapter board required only if connecting a DPHY sensor to PTL(CPHY).
 
 DPHY sensor must be connecting to the front side of adapter.
@@ -201,6 +255,14 @@ Replace target system with recommended [ipu75xa](../../config/isx031/ipu75xa) se
 
     sudo cp -r ../../config/isx031/ipu75xa /etc/camera
     sudo sed -i '/availableSensors/c\        "availableSensors": ["isx031-a-0","isx031-b-2"],' /etc/camera/ipu75xa/libcamhal_configs.json
+
+#### Setup for IPU8
+
+Replace target system with recommended [ipu8](../../config/isx031/ipu8) setting
+
+> **Note:** Add config below only if using x2 MIPI sensors.
+
+    sudo cp -r ../../config/isx031/ipu8 /etc/camera
 
 ## Environment Setup
 


### PR DESCRIPTION
Ports two ISX031 IPU8 commits from the internal repo to the external fork.

## Commits

1. **doc(isx031): add ISX031 IPU8 MIPI configs and BIOS setup guide** (`631c3a4`)
   - Add IPU8 libcamhal config for ISX031
   - Add ISX031 sensor profiles (a/b) for IPU8
   - Document BIOS settings for ISX031 MIPI on IPU8

2. **config(isx031,ipu8): replace hardcoded entity names with placeholders** (`87f4787`)
   - Use `$I2CBUS` and `$CSI_PORT` in `isx031-a.json` / `isx031-b.json` so configs are reusable across different bus/port mappings.

## Files

- `config/isx031/ipu8/libcamhal_configs.json` (new)
- `config/isx031/ipu8/sensors/isx031-a.json` (new)
- `config/isx031/ipu8/sensors/isx031-b.json` (new)
- `doc/isx031/userspace-mipi.md`
