### PR TITLE
Port internal IPU8/NVL platform support and 6.12-intel DKMS fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,25 +28,27 @@ This repository contains reference drivers and configurations for Intel MIPI CSI
 
 ## Supported Sensors
 
-| Sensor          |Sensor Type | Vendor          | IPU Version                |
-|-----------------|------------|-----------------|----------------------------|
-| AR0233+GW5300   | GMSL       | Sensing         | IPU6EPMTL, IPU75XA         |
-| AR0234          | GMSL       | D3 Embedded     | IPU6EPMTL                  |
-| AR0234          | MIPI CSI-2 | D3 Embedded     | IPU6EPMTL                  |
-| AR0820+GW5300   | GMSL       | Sensing         | IPU6EPMTL, IPU75XA         |
-| AR0830+AP1302   | MIPI CSI-2 | Leopard Imaging | IPU6EPMTL, IPU75XA         |
-| ISX031          | GMSL       | D3 Embedded     | IPU6EP, IPU6EPMTL, IPU75XA |
-| ISX031          | GMSL       | Leopard Imaging | IPU6EP, IPU6EPMTL, IPU75XA |
-| ISX031          | GMSL       | Sensing         | IPU6EP, IPU6EPMTL, IPU75XA |
-| ISX031          | MIPI CSI-2 | D3 Embedded     | IPU6EP, IPU6EPMTL, IPU75XA |
-| ISX031          | MIPI CSI-2 | Sensing         | IPU6EP, IPU6EPMTL, IPU75XA |
-| IMX415          | MIPI CSI-2 | Leopard Imaging | IPU6EPMTL                  |
-| IMX586          | MIPI CSI-2 | Leopard Imaging | IPU6EPMTL                  |
+| Sensor          | Sensor Type | Vendor          | IPU Version                      |
+|-----------------|-------------|-----------------|----------------------------------|
+| AR0233+GW5300   | GMSL        | Sensing         | IPU6EPMTL, IPU75XA               |
+| AR0234          | GMSL        | D3 Embedded     | IPU6EPMTL                        |
+| AR0234          | MIPI CSI-2  | D3 Embedded     | IPU6EPMTL                        |
+| AR0820+GW5300   | GMSL        | Sensing         | IPU6EPMTL, IPU75XA               |
+| AR0830+AP1302   | MIPI CSI-2  | Leopard Imaging | IPU6EPMTL, IPU75XA               |
+| ISX031          | GMSL        | D3 Embedded     | IPU6EP, IPU6EPMTL, IPU75XA, IPU8 |
+| ISX031          | GMSL        | Leopard Imaging | IPU6EP, IPU6EPMTL, IPU75XA, IPU8 |
+| ISX031          | GMSL        | Sensing         | IPU6EP, IPU6EPMTL, IPU75XA       |
+| ISX031          | MIPI CSI-2  | D3 Embedded     | IPU6EP, IPU6EPMTL, IPU75XA, IPU8 |
+| ISX031          | MIPI CSI-2  | Sensing         | IPU6EP, IPU6EPMTL, IPU75XA       |
+| IMX415          | MIPI CSI-2  | Leopard Imaging | IPU6EPMTL                        |
+| IMX586          | MIPI CSI-2  | Leopard Imaging | IPU6EPMTL                        |
+| OV13B10         | MIPI CSI-2  | Leopard Imaging | IPU8                             |
 
 > **Note:** \
 IPU6EP represents ADL, TWL, ASL and RPL platforms; \
 IPU6EPMTL represents MTL and ARL platforms; \
-IPU75XA represents PTL platforms.
+IPU75XA represents PTL platforms; \
+IPU8 represents NVL platforms.
 
 ## Supported Ubuntu and Kernel Version
 
@@ -54,8 +56,12 @@ IPU75XA represents PTL platforms.
 |--------------------|-----------------|-----------------|
 | IPU6EP / IPU6EPMTL | 24.04.4         | 6.12 Intel BKC  |
 |                    | 24.04.4         | 6.17 Canonical  |
+|                    | 26.04           | 7.0 Canonical   |
 | IPU75XA            | 24.04.4         | 6.17 Intel BKC  |
 |                    | 24.04.4         | 6.17 Canonical  |
+|                    | 26.04           | 7.0 Canonical   |
+| IPU8               | 24.04.4         | 6.18 Intel BKC  |
+|                    | 24.04.4         | 7.0 IOT Next    |
 
 ## Directory Structure
 

--- a/dkms.conf
+++ b/dkms.conf
@@ -169,14 +169,14 @@ DEST_MODULE_LOCATION[$i]="/updates"
 STRIP[$i]=no
 
 # maxim-serdes drivers require CONFIG_I2C_ATR.
-# 6.17 BKC kernels typically ship with CONFIG_I2C_ATR disabled, so users must
-# rebuild that kernel with CONFIG_I2C_ATR=y to use maxim-serdes.
-# Skip only on 6.17-intel. 6.18-intel and newer are allowed.
-KERNEL_IS_617_INTEL=0
-if [ "$KERNEL_VER" -eq 6 ] && [ "$KERNEL_PATCH" -eq 17 ] && echo "$kernelver" | grep -q -- '-intel'; then
-KERNEL_IS_617_INTEL=1
+# 6.12 and 6.17 BKC kernels typically ship with CONFIG_I2C_ATR disabled, so
+# users must rebuild those kernels with CONFIG_I2C_ATR=y to use maxim-serdes.
+# Skip on 6.12-intel and 6.17-intel. 6.18-intel and newer are allowed.
+KERNEL_SKIP_MAXIM_SERDES=0
+if [ "$KERNEL_VER" -eq 6 ] && { [ "$KERNEL_PATCH" -eq 12 ] || [ "$KERNEL_PATCH" -eq 17 ]; } && echo "$kernelver" | grep -q -- '-intel'; then
+KERNEL_SKIP_MAXIM_SERDES=1
 fi
-if [ "$KERNEL_IS_617_INTEL" -ne 1 ]; then
+if [ "$KERNEL_SKIP_MAXIM_SERDES" -ne 1 ]; then
 BUILT_MODULE_NAME[$((++i))]="max-serdes"
 BUILT_MODULE_LOCATION[$i]="drivers/media/i2c/maxim-serdes"
 DEST_MODULE_LOCATION[$i]="/updates"


### PR DESCRIPTION
Ports the two internal commits whose changes are not yet present upstream:

- **dkms: skip maxim-serdes build on 6.12-intel** — exclude maxim-serdes module build on 6.12-intel kernel.
- **README: add IPU8/NVL platform support** — document IPU8/NVL platform support.

Source: `intel-innersource/drivers.camera.scaling.sensor` main. Cherry-picked onto `intel:main`.