### PR TITLE
max9x: use stream-aware active formats

### DIFF
--- a/drivers/media/i2c/max9x/serdes.c
+++ b/drivers/media/i2c/max9x/serdes.c
@@ -1551,10 +1551,7 @@ static struct v4l2_mbus_framefmt *__max9x_get_ffmt(struct v4l2_subdev *sd,
 		return ERR_PTR(-EINVAL);
 	}
 
-	if (fmt->which == V4L2_SUBDEV_FORMAT_TRY)
-		return v4l2_subdev_state_get_format(v4l2_state, fmt->pad, fmt->stream);
-
-	return &common->v4l.ffmts[fmt->pad];
+	return v4l2_subdev_state_get_format(v4l2_state, fmt->pad, fmt->stream);
 }
 
 static int max9x_get_fmt(struct v4l2_subdev *sd,


### PR DESCRIPTION
## Summary
- use V4L2 subdev state format lookup for MAX9x active formats
- keep active format state stream-aware for deserializer source pads carrying multiple VC streams

## Validation
- rebuilt and installed the DKMS module from patched source
- confirmed `max9x` loads from the DKMS updates path
- validated mixed multi-process streaming together with the HAL active-path setup change
