### PR TITLE
patches: ipu6: Add D4XX support into IPU6 drivers

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -56,6 +56,8 @@ PATCH[$((++j))]="6.18/0054-ipu6-isys-api-compat.patch"
 PATCH_MATCH[$j]="^(6.1[8])"
 PATCH[$((++j))]="7.0/0055-ipu6-k7-api-compat.patch"
 PATCH_MATCH[$j]="^(7\.0)"
+PATCH[$((++j))]="0007-media-pci-ipu6-Add-D4XX-support-to-IPU6.patch"
+PATCH_MATCH[$j]="^(6.1[78]|7\.0)"
 PATCH[$((++j))]="0101-media-ipu6-isys-let-v4l2-set-default-colorspace.patch"
 PATCH_MATCH[$j]="^(6.1[78]|7\.0)"
 

--- a/patches/0007-media-pci-ipu6-Add-D4XX-support-to-IPU6.patch
+++ b/patches/0007-media-pci-ipu6-Add-D4XX-support-to-IPU6.patch
@@ -1,0 +1,82 @@
+--- a/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c
++++ b/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.c
+@@ -42,6 +42,8 @@ static const u32 csi2_supported_codes[] = {
+ 	MEDIA_BUS_FMT_SGBRG8_1X8,
+ 	MEDIA_BUS_FMT_SGRBG8_1X8,
+ 	MEDIA_BUS_FMT_SRGGB8_1X8,
++	MEDIA_BUS_FMT_VYUY8_1X16, /* D4XX specific */
++	MEDIA_BUS_FMT_Y8_1X8, /* D4XX specific */
+ 	MEDIA_BUS_FMT_META_8,
+ 	MEDIA_BUS_FMT_META_10,
+ 	MEDIA_BUS_FMT_META_12,
+--- a/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h
++++ b/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-csi2.h
+@@ -21,7 +21,7 @@ struct ipu6_isys_stream;
+ #define INVALID_VC_ID		-1
+ #define NR_OF_CSI2_SINK_PADS	1
+ #define CSI2_PAD_SINK		0
+-#define NR_OF_CSI2_SRC_PADS	8
++#define NR_OF_CSI2_SRC_PADS	8 /* D4XX specific; modify this number to support more VC */
+ #define CSI2_PAD_SRC		1
+ #define NR_OF_CSI2_PADS		(NR_OF_CSI2_SINK_PADS + NR_OF_CSI2_SRC_PADS)
+
+--- a/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-subdev.c
++++ b/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-subdev.c
+@@ -24,6 +24,7 @@ unsigned int ipu6_isys_mbus_code_to_bpp(u32 code)
+ 	case MEDIA_BUS_FMT_RGB565_1X16:
+ 	case MEDIA_BUS_FMT_UYVY8_1X16:
+ 	case MEDIA_BUS_FMT_YUYV8_1X16:
++	case MEDIA_BUS_FMT_VYUY8_1X16:
+ 	case MEDIA_BUS_FMT_META_16:
+ 		return 16;
+ 	case MEDIA_BUS_FMT_SBGGR12_1X12:
+@@ -43,6 +44,7 @@ unsigned int ipu6_isys_mbus_code_to_bpp(u32 code)
+ 	case MEDIA_BUS_FMT_SGBRG8_1X8:
+ 	case MEDIA_BUS_FMT_SGRBG8_1X8:
+ 	case MEDIA_BUS_FMT_SRGGB8_1X8:
++	case MEDIA_BUS_FMT_Y8_1X8:
+ 	case MEDIA_BUS_FMT_META_8:
+ 		return 8;
+ 	default:
+@@ -60,6 +62,7 @@ unsigned int ipu6_isys_mbus_code_to_mipi(u32 code)
+ 		return MIPI_CSI2_DT_RGB888;
+ 	case MEDIA_BUS_FMT_UYVY8_1X16:
+ 	case MEDIA_BUS_FMT_YUYV8_1X16:
++	case MEDIA_BUS_FMT_VYUY8_1X16:
+ 		return MIPI_CSI2_DT_YUV422_8B;
+ 	case MEDIA_BUS_FMT_SBGGR16_1X16:
+ 	case MEDIA_BUS_FMT_SGBRG16_1X16:
+@@ -82,6 +85,7 @@ unsigned int ipu6_isys_mbus_code_to_mipi(u32 code)
+ 	case MEDIA_BUS_FMT_SGBRG8_1X8:
+ 	case MEDIA_BUS_FMT_SGRBG8_1X8:
+ 	case MEDIA_BUS_FMT_SRGGB8_1X8:
++	case MEDIA_BUS_FMT_Y8_1X8:
+ 		return MIPI_CSI2_DT_RAW8;
+ 	default:
+ 		/* return unavailable MIPI data type - 0x3f */
+--- a/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-video.c
++++ b/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys-video.c
+@@ -88,6 +88,15 @@ const struct ipu6_isys_pixelformat ipu6_isys_pfmts[] = {
+ 	  IPU6_FW_ISYS_FRAME_FORMAT_RGB565 },
+ 	{ V4L2_PIX_FMT_BGR24, 24, 24, MEDIA_BUS_FMT_RGB888_1X24,
+ 	  IPU6_FW_ISYS_FRAME_FORMAT_RGBA888 },
++	/* D4XX specific */
++	{ V4L2_PIX_FMT_Z16, 16, 16, MEDIA_BUS_FMT_UYVY8_1X16,
++	  IPU6_FW_ISYS_FRAME_FORMAT_UYVY },
++	{ V4L2_PIX_FMT_Y8I, 16, 16, MEDIA_BUS_FMT_VYUY8_1X16,
++	  IPU6_FW_ISYS_FRAME_FORMAT_UYVY },
++	{ V4L2_PIX_FMT_Y12I, 32, 24, MEDIA_BUS_FMT_RGB888_1X24, /* TODO: To be verified */
++	  IPU6_FW_ISYS_FRAME_FORMAT_RGBA888 },
++	{ V4L2_PIX_FMT_GREY, 8, 8, MEDIA_BUS_FMT_Y8_1X8,
++	  IPU6_FW_ISYS_FRAME_FORMAT_RAW8 },
+ 	{ V4L2_META_FMT_GENERIC_8, 8, 8, MEDIA_BUS_FMT_META_8,
+ 	  IPU6_FW_ISYS_FRAME_FORMAT_RAW8, true },
+ 	{ V4L2_META_FMT_GENERIC_CSI2_10, 10, 10, MEDIA_BUS_FMT_META_10,
+--- a/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys.h
++++ b/ipu6-drivers/drivers/media/pci/intel/ipu6/ipu6-isys.h
+@@ -46,4 +46,4 @@ struct ipu6_isys_pdata;
+ #define IPU6_ISYS_MIN_WIDTH		2U
+-#define IPU6_ISYS_MIN_HEIGHT		2U
++#define IPU6_ISYS_MIN_HEIGHT		1U /* D4XX specific */
+ #define IPU6_ISYS_MAX_WIDTH		4672U
+ #define IPU6_ISYS_MAX_HEIGHT		3416U

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -144,6 +144,12 @@ declare -A STREAM_NODE=(
     [imu]=3
     [yuv]=0
 )
+
+# Keep capture-node groups consistent across 2-link and 4-link deserializers:
+# depth uses offsets 0..3, rgb 4..7,
+# TODO: ir and imu to have different offsets.
+CSI2_STREAM_STRIDE=4
+
 # STREAM_MUXPAD: sink pad on a d4xx-style mux subdev. Only needed for streams
 # that flow through such a mux, usually a 3D sensor.
 declare -A STREAM_MUXPAD=(
@@ -530,13 +536,14 @@ print_topology() {
 # applied to every link discovered under every deserializer.
 #
 # Capture-node layout (per DES) -- STREAM-MAJOR:
-#     csi2_pad = STREAM_NODE[s] * DES_MAX_LINKS[d] + l
+#     csi2_pad = STREAM_NODE[s] * CSI2_STREAM_STRIDE + l
 #     node     = CAPTURE_BASE[d] + csi2_pad
-# Nodes are grouped by stream type across links: e.g. for a 4-link max96724
-# with d4xx, depth lands on nodes base+0..3, rgb on base+4..7, etc. For
-# 1-stream sensors like isx031, 4 links land on base+0..3 directly. The
-# CSI2 RX cap is IPU7_NR_OF_CSI2_SRC_PADS (16 with the D4XX patch applied;
-# 8 otherwise); the resulting pad must stay within that.
+# Nodes are grouped by stream type in fixed groups of four for both max9296a
+# and max96724: depth lands on base+0..3, rgb on base+4..7, etc. Unused links
+# leave gaps on 2-link deserializers. For 1-stream sensors like isx031, links
+# land on base+0..3 directly. The CSI2 RX cap is IPU*_NR_OF_CSI2_SRC_PADS;
+# set IPU_CSI2_SRC_PADS to match (commonly 8 or 16). The resulting pad must
+# stay within that.
 #
 # v4l2 source_stream tag at the deserializer source pad / CSI2 sink pad is
 # allocated separately as a compact per-DES sequential id (0..3), because
@@ -683,15 +690,18 @@ for k in "${!CFG_LINKS[@]}"; do
     l=${CFG_LINKS[$k]}
     key="${d}_${l}"
     for s in ${CFG_STREAMS[$k]}; do
-        pad=$(( STREAM_NODE[$s] * DES_MAX_LINKS[d] + l ))
+        pad=$(( STREAM_NODE[$s] * CSI2_STREAM_STRIDE + l ))
         if (( pad >= IPU_CSI2_SRC_PADS )); then
-            die "DES${d} link ${l} stream ${s}: csi2_pad ${pad} exceeds IPU7 cap (${IPU_CSI2_SRC_PADS}); rebuild with the D4XX patch (raises cap to 16) or reduce active links/streams"
+            die "DES${d} link ${l} stream ${s}: csi2_pad ${pad} exceeds CSI2 src-pad cap "\
+            "(${IPU_CSI2_SRC_PADS}); reduce active links/streams or rebuild the kernel with a "\
+            "higher *_NR_OF_CSI2_SRC_PADS"
         fi
         CSI2_PAD["${k}_${s}"]=$pad
 
         ds=${DES_STREAM_NEXT[$d]:-0}
         if (( ds >= 4 )); then
-            die "DES${d}: too many streams routed through deserializer source pad (max96724 supports 4 unique source_streams)"
+            die "DES${d}: too many streams routed through deserializer source pad (maxim-serdes "\
+            "supports 4 unique source_streams)"
         fi
         DES_STREAM["${k}_${s}"]=$ds
         DES_STREAM_NEXT[$d]=$(( ds + 1 ))


### PR DESCRIPTION
This enables D457 to stream with IPU6