### PR TITLE
media: ipu6: Add MIPI serializer/deserializer enhancements

### DIFF
--- a/acpi/ipu6/_des_common_max9296.asl
+++ b/acpi/ipu6/_des_common_max9296.asl
@@ -9,7 +9,12 @@
  *   DES_TO_MIPI_PORT       - DES connected to MIPI Port (e.g. 0/1/2/3) of IPU0 Device, used as IPU remote port in CSI2Bus
  *   DES_I2C_ADDR           - DES I2C slave address (e.g. 0x0048 for MAX9296A), used in I2cSerialBusV2
  *   DES_I2C_BUS            - DES I2C bus path string (e.g. "\\_SB.PC00.I2C1"), used in I2cSerialBusV2
+ *   LINK_FREQ              - Optional link frequency; defaults to 700 MHz
  */
+
+#ifndef LINK_FREQ
+#define LINK_FREQ 700000000
+#endif
 
 Name (_UID, Zero)               // _UID: Unique ID
 
@@ -111,7 +116,7 @@ Name (PRT2, Package()
         #else
         Package () { "mipi-img-data-lanes", Package () { 1, 2, 3, 4 } },
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 700000000 } }, // 700 MHz link frequency (DDR => 1.4 Gbps lane rate)
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },
     },
 })
 

--- a/acpi/ipu6/_des_common_max9296.asl
+++ b/acpi/ipu6/_des_common_max9296.asl
@@ -111,7 +111,7 @@ Name (PRT2, Package()
         #else
         Package () { "mipi-img-data-lanes", Package () { 1, 2, 3, 4 } },
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { 700000000 } }, // 700 MHz link frequency (DDR => 1.4 Gbps lane rate)
     },
 })
 

--- a/acpi/ipu6/_des_common_max96724.asl
+++ b/acpi/ipu6/_des_common_max96724.asl
@@ -162,10 +162,15 @@ Name (PRT5, Package()
     ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"), // Device Properties
     Package ()
     {
-        Package () { "mipi-img-clock-lanes", 0 },
         #if DES_LANES == 4
+            #if DES_PHY_TYPE == 1
+            Package () { "mipi-img-clock-lanes", 5 }, // DPHY uses alternate CKCP PHY0 clock lane
+            #else
+            Package () { "mipi-img-clock-lanes", 0 },
+            #endif
         Package () { "mipi-img-data-lanes", Package() { 1, 2, 3, 4 } },       // 4 lanes for DPHY on Intel MIPI CRD
         #else
+        Package () { "mipi-img-clock-lanes", 0 },
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
         Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },

--- a/acpi/ipu6/_des_common_max96724.asl
+++ b/acpi/ipu6/_des_common_max96724.asl
@@ -10,7 +10,12 @@
  *   DES_I2C_ADDR           - DES I2C slave address (e.g. 0x0027 for MAX96724), used in I2cSerialBusV2
  *   DES_I2C_BUS            - DES I2C bus path string (e.g. "\\_SB.PC00.I2C1"), used in I2cSerialBusV2
  *   DES_PIPE_STR_AUTOSELECT - MAX96724 specific property
+ *   LINK_FREQ              - Optional link frequency; defaults to 1 GHz
  */
+
+#ifndef LINK_FREQ
+#define LINK_FREQ 1000000000
+#endif
 
 Name (_UID, Zero)               // _UID: Unique ID
 
@@ -148,7 +153,7 @@ Name (PRT4, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },
     },
 })
 
@@ -163,7 +168,7 @@ Name (PRT5, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },
     },
 })
 
@@ -178,7 +183,7 @@ Name (PRT6, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },
     },
 })
 
@@ -193,6 +198,6 @@ Name (PRT7, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ } },
     },
 })

--- a/acpi/ipu6/max9296_d3_isx031.asl
+++ b/acpi/ipu6/max9296_d3_isx031.asl
@@ -49,6 +49,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0
@@ -122,6 +123,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
 
         Device (DES1)
@@ -135,6 +137,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C0"
             #define DES_PATH "\\_SB.PC00.DES1"
             #define DES_REF \_SB.PC00.DES1
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0
@@ -208,6 +211,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/acpi/ipu6/max9296_li_isx031.asl
+++ b/acpi/ipu6/max9296_li_isx031.asl
@@ -49,6 +49,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0
@@ -90,6 +91,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/acpi/ipu6/max9296_mixed.asl
+++ b/acpi/ipu6/max9296_mixed.asl
@@ -60,6 +60,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260520)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0 (LI ISX031)
@@ -135,6 +136,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260520)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
 
         Device (DES1)
@@ -148,6 +150,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260520)
             #define DES_I2C_BUS "\\_SB.PC00.I2C0"
             #define DES_PATH "\\_SB.PC00.DES1"
             #define DES_REF \_SB.PC00.DES1
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0 (D3 ISX031)
@@ -229,6 +232,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260520)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/acpi/ipu6/max9296_rs_d457.asl
+++ b/acpi/ipu6/max9296_rs_d457.asl
@@ -57,6 +57,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0 (RS D457)
@@ -146,6 +147,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
 
         Device (DES1)
@@ -159,6 +161,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C0"
             #define DES_PATH "\\_SB.PC00.DES1"
             #define DES_REF \_SB.PC00.DES1
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0 (RS D457)
@@ -248,6 +251,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/acpi/ipu6/max9296_sensing_isx031.asl
+++ b/acpi/ipu6/max9296_sensing_isx031.asl
@@ -52,6 +52,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 700000000
             #include "_des_common_max9296.asl"
 
             // Channel 0 (with extra GPIO pin 7 and fsin-gpios)
@@ -96,6 +97,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/acpi/ipu6/max96724_dphy_d3_isx031.asl
+++ b/acpi/ipu6/max96724_dphy_d3_isx031.asl
@@ -53,6 +53,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 1000000000
             #include "_des_common_max96724.asl"
 
             // Channel 0 (CH00)
@@ -164,6 +165,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
 
         Device (DES1)
@@ -182,6 +184,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C0"
             #define DES_PATH "\\_SB.PC00.DES1"
             #define DES_REF \_SB.PC00.DES1
+            #define LINK_FREQ 1000000000
             #include "_des_common_max96724.asl"
 
             // Channel 0 (CH00)
@@ -293,6 +296,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/drivers/media/i2c/maxim-serdes/max9296a.c
+++ b/drivers/media/i2c/maxim-serdes/max9296a.c
@@ -1145,6 +1145,34 @@ static void max9296a_remove(struct i2c_client *client)
 	gpiod_set_value_cansleep(priv->gpiod_pwdn, 1);
 }
 
+static int max9296a_suspend(struct device *dev)
+{
+	struct max9296a_priv *priv = dev_get_drvdata(dev);
+
+	if (!priv)
+		return 0;
+
+	return max_des_suspend(&priv->des);
+}
+
+static int max9296a_resume(struct device *dev)
+{
+	struct max9296a_priv *priv = dev_get_drvdata(dev);
+	int ret;
+
+	if (!priv)
+		return 0;
+
+	ret = max9296a_reset(priv);
+	if (ret)
+		return ret;
+
+	return max_des_resume(&priv->des);
+}
+
+static DEFINE_SIMPLE_DEV_PM_OPS(max9296a_pm_ops,
+				max9296a_suspend, max9296a_resume);
+
 static const struct max_serdes_phys_config max9296a_phys_configs[] = {
 	{ { 4, 4 } },
 };
@@ -1339,6 +1367,7 @@ static struct i2c_driver max9296a_i2c_driver = {
 		.name = "max9296a",
 		.of_match_table	= max9296a_of_table,
 		.acpi_match_table = max9296a_acpi_ids,
+		.pm = pm_sleep_ptr(&max9296a_pm_ops),
 	},
 	.probe = max9296a_probe,
 	.remove = max9296a_remove,

--- a/drivers/media/i2c/maxim-serdes/max96724.c
+++ b/drivers/media/i2c/maxim-serdes/max96724.c
@@ -85,6 +85,8 @@
 #define MAX96724_MIPI_PHY0_PHY_2X4		BIT(2)
 #define MAX96724_MIPI_PHY0_PHY_1X4A_2X2		BIT(3)
 #define MAX96724_MIPI_PHY0_PHY_1X4B_2X2		BIT(4)
+#define MAX96724_MIPI_PHY0_CLK_PHY0			BIT(5)
+#define MAX96724_MIPI_PHY0_CLK_PHY3			BIT(6)
 #define MAX96724_MIPI_PHY0_FORCE_CSI_OUT_EN	BIT(7)
 
 #define MAX96724_MIPI_PHY2			0x8a2
@@ -508,6 +510,24 @@ static int max96724_init_phy(struct max_des *des, struct max_des_phy *phy)
 
 	ret = regmap_assign_bits(priv->regmap, MAX96724_MIPI_TX10(index),
 				 MAX96724_MIPI_TX10_CSI2_CPHY_EN, is_cphy);
+	if (ret)
+		return ret;
+
+	switch (phy->mipi.clock_lane) {
+	case 0:
+		val = MAX96724_MIPI_PHY0_CLK_PHY3;
+		break;
+	case 5:
+		val = MAX96724_MIPI_PHY0_CLK_PHY0;
+		break;
+	default:
+		dev_err(priv->dev, "Invalid clock lane %u for PHY %u\n",
+			phy->mipi.clock_lane, phy->index);
+		return -EINVAL;
+	}
+
+	ret = regmap_assign_bits(priv->regmap, MAX96724_MIPI_PHY0,
+		MAX96724_MIPI_PHY0_CLK_PHY0 | MAX96724_MIPI_PHY0_CLK_PHY3, val);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
This PR bundles four interconnected improvements to the IPU6 camera subsystem:

1. **MAX96724 Clock Lane Support** - Adds flexible DPHY clock lane selection 
   (lane 0 or lane 5) with validation

2. **Link Frequency Configuration** - Establishes optimal default frequencies:
   - MAX9296: 700MHz (2 cameras)
   - MAX96724: 1GHz (4 cameras)

3. **Pink Frame Fix** - Reduces MAX9296 frequency to 700MHz to eliminate 
   deskew-related video artifacts

4. **Power Management** - Adds suspend/resume support for MAX9296A deserializer

