### PR TITLE
media: Add configurable mc-setup and 8-camera AR0234 IPU7 support

### DIFF
--- a/acpi/ipu7/max96724_d3_ar0234.asl
+++ b/acpi/ipu7/max96724_d3_ar0234.asl
@@ -3,8 +3,8 @@
  * Copyright (c) 2026 Intel Corporation.
  *
  * SSDT overlay: D3 AR0234 GMSL camera configuration on PTL platform
- *   One MAX96724 deserializers (DES0) with CPHY connection to PTL platform,
- *   each carrying two D3 AR0234 cameras over GMSL Links 0..1, fronted by MAX9295A serializers.
+ *   Two MAX96724 deserializers (DES0, DES1) with CPHY connection to PTL platform,
+ *   each carrying four D3 AR0234 cameras over GMSL Links 0..3, fronted by MAX9295A serializers.
  *
  * DES-level defines (set per DESx, undef'd at the end of each Device):
  *   DES_PHY_TYPE       - DES PHY type (0 for CPHY, 1 for DPHY)
@@ -30,7 +30,7 @@
  *   CAM_LANES          - Number of MIPI data lanes for the camera (e.g. 2, 4)
  */
 
-DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260819)
+DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260820)
 {
     External (_SB.PC00, DeviceObj) // Root device
 
@@ -56,57 +56,236 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260819)
             #define DES_REF \_SB.PC00.DES0
             #include "_des_common_max96724.asl"
 
-            // Channel-level defines for Channel 0 (CH00)
+            // Channel-level defines for Channel 0
+            #define DESCH_LINK_NUM 0
             #define DESCH_CH CH00
             #define DESCH_SER SER0
             #define DESCH_CAM CAM0
+            #define DESCH_SER_I2C 0x40
             #define DESCH_CH_PATH "\\_SB.PC00.DES0.CH00"
             #define DESCH_SER_PATH "\\_SB.PC00.DES0.CH00.SER0"
             #define DESCH_SER_REF \_SB.PC00.DES0.CH00.SER0
-            #define DESCH_LINK_NUM 0
-            #define DESCH_SER_I2C 0x40
             #define DESCH_SER_GPIOREF ^^SER0
             #define CAM_ALIAS 0x54
             #define CAM_LANES 2
             #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
             #undef DESCH_CH
             #undef DESCH_SER
             #undef DESCH_CAM
+            #undef DESCH_SER_I2C
             #undef DESCH_CH_PATH
             #undef DESCH_SER_PATH
             #undef DESCH_SER_REF
-            #undef DESCH_LINK_NUM
-            #undef DESCH_SER_I2C
             #undef DESCH_SER_GPIOREF
             #undef CAM_ALIAS
             #undef CAM_LANES
 
-            // Channel 1
+            // Channel-level defines for Channel 1
+            #define DESCH_LINK_NUM 1
             #define DESCH_CH CH01
             #define DESCH_SER SER1
             #define DESCH_CAM CAM1
+            #define DESCH_SER_I2C 0x40
             #define DESCH_CH_PATH "\\_SB.PC00.DES0.CH01"
             #define DESCH_SER_PATH "\\_SB.PC00.DES0.CH01.SER1"
             #define DESCH_SER_REF \_SB.PC00.DES0.CH01.SER1
-            #define DESCH_LINK_NUM 1
-            #define DESCH_SER_I2C 0x40
             #define DESCH_SER_GPIOREF ^^SER1
             #define CAM_ALIAS 0x55
             #define CAM_LANES 2
             #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
             #undef DESCH_CH
             #undef DESCH_SER
             #undef DESCH_CAM
+            #undef DESCH_SER_I2C
             #undef DESCH_CH_PATH
             #undef DESCH_SER_PATH
             #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Channel-level defines for Channel 2
+            #define DESCH_LINK_NUM 2
+            #define DESCH_CH CH02
+            #define DESCH_SER SER2
+            #define DESCH_CAM CAM2
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES0.CH02"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES0.CH02.SER2"
+            #define DESCH_SER_REF \_SB.PC00.DES0.CH02.SER2
+            #define DESCH_SER_GPIOREF ^^SER2
+            #define CAM_ALIAS 0x56
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
             #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
             #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Channel-level defines for Channel 3
+            #define DESCH_LINK_NUM 3
+            #define DESCH_CH CH03
+            #define DESCH_SER SER3
+            #define DESCH_CAM CAM3
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES0.CH03"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES0.CH03.SER3"
+            #define DESCH_SER_REF \_SB.PC00.DES0.CH03.SER3
+            #define DESCH_SER_GPIOREF ^^SER3
+            #define CAM_ALIAS 0x57
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
+            #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
             #undef DESCH_SER_GPIOREF
             #undef CAM_ALIAS
             #undef CAM_LANES
 
             // Clean up DES0-level defines
+            #undef DES_PHY_TYPE
+            #undef DES_I2C_ADDR
+            #undef DES_LANES
+            #undef DES_INTERNAL_PHY
+            #undef DES_TO_MIPI_PORT
+            #undef DES_I2C_BUS
+            #undef DES_PATH
+            #undef DES_REF
+        }
+
+        Device (DES1)
+        {
+            /*
+             * For detailed explanation of each define,
+             * please refer to the comment block at the top of this file.
+             */
+
+            // DES-level defines for DES1.
+            #define DES_PHY_TYPE 0
+            #define DES_I2C_ADDR 0x0027
+            #define DES_LANES 2
+            #define DES_INTERNAL_PHY 4
+            #define DES_TO_MIPI_PORT 2
+            #define DES_I2C_BUS "\\_SB.PC00.I2C2"
+            #define DES_PATH "\\_SB.PC00.DES1"
+            #define DES_REF \_SB.PC00.DES1
+            #include "_des_common_max96724.asl"
+
+            // Channel-level defines for Channel 0
+            #define DESCH_LINK_NUM 0
+            #define DESCH_CH CH00
+            #define DESCH_SER SER0
+            #define DESCH_CAM CAM0
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES1.CH00"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES1.CH00.SER0"
+            #define DESCH_SER_REF \_SB.PC00.DES1.CH00.SER0
+            #define DESCH_SER_GPIOREF ^^SER0
+            #define CAM_ALIAS 0x54
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
+            #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Channel-level defines for Channel 1
+            #define DESCH_LINK_NUM 1
+            #define DESCH_CH CH01
+            #define DESCH_SER SER1
+            #define DESCH_CAM CAM1
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES1.CH01"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES1.CH01.SER1"
+            #define DESCH_SER_REF \_SB.PC00.DES1.CH01.SER1
+            #define DESCH_SER_GPIOREF ^^SER1
+            #define CAM_ALIAS 0x55
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
+            #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Channel-level defines for Channel 2
+            #define DESCH_LINK_NUM 2
+            #define DESCH_CH CH02
+            #define DESCH_SER SER2
+            #define DESCH_CAM CAM2
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES1.CH02"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES1.CH02.SER2"
+            #define DESCH_SER_REF \_SB.PC00.DES1.CH02.SER2
+            #define DESCH_SER_GPIOREF ^^SER2
+            #define CAM_ALIAS 0x56
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
+            #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Channel-level defines for Channel 3
+            #define DESCH_LINK_NUM 3
+            #define DESCH_CH CH03
+            #define DESCH_SER SER3
+            #define DESCH_CAM CAM3
+            #define DESCH_SER_I2C 0x40
+            #define DESCH_CH_PATH "\\_SB.PC00.DES1.CH03"
+            #define DESCH_SER_PATH "\\_SB.PC00.DES1.CH03.SER3"
+            #define DESCH_SER_REF \_SB.PC00.DES1.CH03.SER3
+            #define DESCH_SER_GPIOREF ^^SER3
+            #define CAM_ALIAS 0x57
+            #define CAM_LANES 2
+            #include "_des_ch_common_ar0234.asl"
+            #undef DESCH_LINK_NUM
+            #undef DESCH_CH
+            #undef DESCH_SER
+            #undef DESCH_CAM
+            #undef DESCH_SER_I2C
+            #undef DESCH_CH_PATH
+            #undef DESCH_SER_PATH
+            #undef DESCH_SER_REF
+            #undef DESCH_SER_GPIOREF
+            #undef CAM_ALIAS
+            #undef CAM_LANES
+
+            // Clean up DES1-level defines
             #undef DES_PHY_TYPE
             #undef DES_I2C_ADDR
             #undef DES_LANES

--- a/config/ar0234/ipu75xa/sensors/ar0234.json
+++ b/config/ar0234/ipu75xa/sensors/ar0234.json
@@ -20,7 +20,7 @@
       {
         "name": "ar0234_acpi-1",
         "description": "AR0234 GMSL Sensor 1",
-        "vcCount": 2,
+        "vcCount": 4,
         "vcId": 0,
         "vcGroupId": 0,
         "MediaCtlConfig": [
@@ -31,7 +31,7 @@
             "videonode": [
               { "name": "Intel IPU7 ISYS Capture 0", "videoNodeType": "VIDEO_GENERIC" },
               { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
-              { "name": "ar0234 22-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+              { "name": "ar0234 28-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
             ]
           }
         ],
@@ -212,7 +212,7 @@
       {
         "name": "ar0234_acpi-2",
         "description": "AR0234 GMSL Sensor 2",
-        "vcCount": 2,
+        "vcCount": 4,
         "vcId": 1,
         "vcGroupId": 0,
         "MediaCtlConfig": [
@@ -223,7 +223,1159 @@
             "videonode": [
               { "name": "Intel IPU7 ISYS Capture 1", "videoNodeType": "VIDEO_GENERIC" },
               { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
-              { "name": "ar0234 23-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+              { "name": "ar0234 29-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-3",
+        "description": "AR0234 GMSL Sensor 3",
+        "vcCount": 4,
+        "vcId": 2,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 2", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 30-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-4",
+        "description": "AR0234 GMSL Sensor 4",
+        "vcCount": 4,
+        "vcId": 3,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 3", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 0", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 31-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-5",
+        "description": "AR0234 GMSL Sensor 5",
+        "vcCount": 4,
+        "vcId": 0,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0 ,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 16", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 32-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-6",
+        "description": "AR0234 GMSL Sensor 6",
+        "vcCount": 4,
+        "vcId": 1,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0 ,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 17", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 33-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-7",
+        "description": "AR0234 GMSL Sensor 7",
+        "vcCount": 4,
+        "vcId": 2,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0 ,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 18", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 34-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
+            ]
+          }
+        ],
+        "StaticMetadata": {
+          "supportedStreamConfig": [
+            { "format": "V4L2_PIX_FMT_NV12", "size": [1280, 960], "field": 0, "mcId": 0 }
+          ],
+          "supportedFeatures": [
+            "MANUAL_EXPOSURE",
+            "MANUAL_WHITE_BALANCE",
+            "IMAGE_ENHANCEMENT",
+            "NOISE_REDUCTION",
+            "PER_FRAME_CONTROL",
+            "SCENE_MODE"
+          ],
+          "fpsRange": [ 10, 30 ],
+          "evRange": [ -6, 6 ],
+          "evStep": [ 1, 3 ],
+          "supportedAeMode": [
+            "AUTO",
+            "MANUAL"
+          ],
+          "supportedVideoStabilizationModes": [
+            "OFF"
+          ],
+          "supportedSceneMode": [
+            "NORMAL"
+          ],
+          "supportedAntibandingMode": [
+            "AUTO",
+            "50Hz",
+            "60Hz",
+            "OFF"
+          ],
+          "supportedAwbMode": [
+            "AUTO",
+            "INCANDESCENT",
+            "FLUORESCENT",
+            "DAYLIGHT",
+            "FULL_OVERCAST",
+            "PARTLY_OVERCAST",
+            "SUNSET",
+            "VIDEO_CONFERENCE",
+            "MANUAL_CCT_RANGE",
+            "MANUAL_WHITE_POINT",
+            "MANUAL_GAIN",
+            "MANUAL_COLOR_TRANSFORM"
+          ],
+          "supportedAfMode": [
+            "OFF"
+          ],
+          "metadata":{
+            "ae.lockAvailable": [1],
+            "awb.lockAvailable": [1],
+            // 0: OFF, 1: AUTO, 2: USE_SCENE_MODE, 3: OFF_KEEP_STATE
+            "control.availableModes" : [ 0, 1 ],
+            // 0: DISABLE, 1: FACE_PRIORITY
+            "control.availableSceneModes": [1],
+            "control.maxRegions" : [ 1, 0, 1 ],
+            // 0: OFF, 1: SIMPLE, 2: FULL
+            "statistics.info.availableFaceDetectModes" : [0],
+            "sensor.orientation" : [0],
+            // 43*15.9
+            "sensor.maxAnalogSensitivity" : [699],
+            "sensor.info.sensitivityRange" : [44, 1399],
+            // align with supportedAeExposureTimeRange
+            "sensor.info.exposureTimeRange": [ 100, 100000 ],
+            "sensor.info.activeArraySize": [ 0, 0, 1280, 960 ],
+            "sensor.info.pixelArraySize": [1280, 960],
+            // 1280x1.12um 960x1.12um
+            "sensor.info.physicalSize": [ 4.71, 3.49 ],
+            //  0: off, 1: solid color, 2: color bars
+            "sensor.availableTestPatternModes": [ 0, 2 ],
+            // 0:RGGB, 1:GRBG, 2:GBRG, 3:BGGR, 4:RGB
+            "sensor.info.colorFilterArrangement": [1],
+            // shading 0:OFF,1:FAST,2:HIGH_QUALITY
+            "shading.availableModes": [ 0, 1, 2 ],
+            "lens.facing": [1],
+            "lens.info.availableApertures": [2.2],
+            "lens.info.availableFilterDensities": [0.0],
+            "lens.info.availableFocalLengths": [3.39],
+            "lens.info.availableOpticalStabilization": [0],
+            "lens.info.hyperfocalDistance": [1.37],
+            "lens.info.minimumFocusDistance": [10.0],
+            "lens.info.shadingMapSize": [ 63, 47 ],
+            "lens.info.focusDistanceCalibration": [1],
+            // raw, yuv, jpeg
+            "request.maxNumOutputStreams": [ 1, 3, 1 ],
+            // 0: No input, 1: 1 input stream (YUV or RAW), 2: 2 input streams (YUV and RAW)
+            "request.maxNumInputStreams": [1],
+            "request.pipelineMaxDepth": [7],
+            // 0:backward, 1:manual_sensor, 2:manual_pso_processing, 3:raw, 4:zsl, 5:read_sensor_settings, 6:burst_capture, 7: yuv reprocessing
+            "request.availableCapabilities": [ 0, 1, 2, 4, 5, 6 ],
+            // input fmt, output fmt number, output fmts; fmt: YCbCr_420_888:0x23 (35), IMPLEMENTATION_DEFINED:0x22 (34), Blob:0x21 (33)
+            "scaler.availableInputOutputFormatsMap": [ 34, 2, 33, 35 ],
+            "sensor.opaqueRawSize": [1280, 960, 100],
+            // available stream configurations: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, type: output(0)|input(1)
+            "scaler.availableStreamConfigurations": [
+                  33, 1280,  960, 0,
+                  35, 1280,  960, 0,
+                  34, 1280,  960, 0
+            ],
+            // minimum frame duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableMinFrameDurations": [
+                  33, 1280,  960, 33333333,
+                  35, 1280,  960, 33333333,
+                  34, 1280,  960, 33333333
+            ],
+            // maximum stall duration: format: IMPLEMENTATION_DEFINED(34)|YCbCr_420_888:0x23(35)|BLOB(33), widthxheight, duration:(ns)
+            "scaler.availableStallDurations": [
+                  33, 1280,  960, 33333333
+            ],
+            // maximum JPEG size: 1920*1200*1.5
+            "jpeg.maxSize": [3456000],
+            // INCREASING ORDER
+            "jpeg.availableThumbnailSizes": [ 0, 0, 320, 180, 320, 240 ],
+            // 0:off, 1:fast, 2:high_quality, 3:zero_shutter_lag
+            "edge.availableEdgeModes": [ 0, 1, 2, 3 ],
+            // 0:off, 1:fast, 2:high_quality
+            "hotPixel.availableHotPixelModes": [ 1, 2 ],
+            // 0:off, 1:fast, 2:high_quality, 3:minimal, 4:zero_shutter_lag
+            "noiseReduction.availableNoiseReductionModes": [ 0, 1, 2, 4 ],
+            "tonemap.maxCurvePoints": [1024],
+            // 0:contrast_curve, 1:fast, 2:high_quality, 3:gamma_value, 4:preset_curve
+            "tonemap.availableToneMapModes": [ 1, 2, 3, 4 ],
+            // Number of frames
+            "reprocess.maxCaptureStall": [4],
+            // 0:limited, 1:full, 2:legacy, 3:level3
+            "info.supportedHardwareLevel": [1],
+            // 0:per-frame, -1:unknown, other positive number:frame count
+            "sync.maxLatency": [0]
+          }
+        },
+        "supportedTuningConfig": [
+          ["NORMAL", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"],
+          ["STILL_CAPTURE", "VIDEO", "AR0234_GRBG_1280_960_PTL.IPU75XA"]
+        ],
+        // The lard tags configuration. Every tag should be 4-characters.
+        // TuningMode, cmc tag, aiq tag, isp tag, others tag
+        "lardTags": [
+          ["VIDEO", "DFLT", "DFLT", "DFLT", "DFLT"]
+        ],
+        // ascending order request
+        "supportedISysSizes": [[1280, 960]],
+        "supportedISysFormat": ["V4L2_PIX_FMT_SGRBG10"],
+        "enableAIQ": true,
+        "iSysRawFormat": "V4L2_PIX_FMT_SGRBG10",
+        "maxRawDataNum": 32,
+        "initialSkipFrame": 0,
+        "exposureLag": 2,
+        "gainLag": 0,
+        "digitalGainLag": 0,
+        "yuvColorRangeMode": "full",
+        "pipeSwitchDelayFrame": 60,
+        "graphSettingsFile": "AR0234.IPU75XA.bin",
+        "graphSettingsType": "coupled",
+        "enablePSysProcessor": true,
+        "dvsType": "IMG_TRANS",
+        "nvmDeviceInfo": ["NVM", 590],
+        "lensName": "dw9714",
+        "lensHwType": "LENS_VCM_HW",
+        "testPatternMap": {
+          "Off": 0,
+          "ColorBars": 1
+        },
+        "enableAiqd": true,
+        "useCrlModule": false,
+        "pslOutputMapForRotation": [
+          [[1280, 960], [1280, 960]]
+        ],
+        "maxRequestsInflight": 6,
+        "psysBundleWithAic": false,
+        "skipFrameV4L2Error": true,
+        "isISYSCompression": false,
+        "isPSACompression": false,
+        "usingMockPSys": false
+      },
+      {
+        "name": "ar0234_acpi-8",
+        "description": "AR0234 GMSL Sensor 8",
+        "vcCount": 4,
+        "vcId": 3,
+        "vcGroupId": 0,
+        "MediaCtlConfig": [
+          {
+            "id":  0 ,
+            "configMode": "AUTO",
+            "output": [1280, 960],
+            "videonode": [
+              { "name": "Intel IPU7 ISYS Capture 19", "videoNodeType": "VIDEO_GENERIC" },
+              { "name": "Intel IPU7 CSI2 2", "videoNodeType": "VIDEO_ISYS_RECEIVER" },
+              { "name": "ar0234 35-0010", "videoNodeType": "VIDEO_PIXEL_ARRAY" }
             ]
           }
         ],

--- a/doc/ar0234/userspace-gmsl.md
+++ b/doc/ar0234/userspace-gmsl.md
@@ -2,51 +2,40 @@
 
 This document details the configuration settings for the AR0234 GMSL sensor, providing essential information for system integration. The table below presents the key parameters and their respective values used during system setup and validation.
 
-<!-- TABLE OF CONTENTS -->
-<details>
-  <summary>Table of Contents</summary>
-  <ol>
-    <li><a href="#hardware-connection">Hardware Connection</a>
-      <ul>
-        <li><a href="#max9296-aic-rev-b-connection">MAX9296 AIC (REV B) Connection</a></li>
-        <li><a href="#max96724-aic-c-phy-rev-a-connection">MAX96724 AIC (C-PHY) (REV A) Connection</a></li>
-        <li><a href="#max96724-aic-c-phy-rev-b-connection">MAX96724 AIC (C-PHY) (REV B) Connection</a></li>
-        <li><a href="#max96724-aic-d-phy-rev-b-connection">MAX96724 AIC (D-PHY) (REV B) Connection</a></li>
-        <li><a href="#max96724-aic-c-phy-to-d-phy-adapter-rev-b-connection">MAX96724 AIC (C-PHY to D-PHY Adapter) (REV B) Connection</a></li>
-      </ul>
-    </li>
-    <li><a href="#bios-configuration-table">BIOS Configuration Table</a>
-      <ul>
-        <li><a href="#disable-c-states">Disable C States</a></li>
-      </ul>
-    </li>
-    <li><a href="#mipi-camera-configuration">MIPI Camera Configuration</a>
-      <ul>
-        <li><a href="#setup-for-ipu6epmtl">Setup for IPU6EPMTL</a></li>
-        <li><a href="#setup-for-ipu75xa">Setup for IPU75XA</a></li>
-        <li><a href="#setup-for-ipu8">Setup for IPU8</a></li>
-      </ul>
-    </li>
-    <li><a href="#camera-configuration-file-setup">Camera Configuration File Setup</a>
-      <ul>
-        <li><a href="#setup-for-ipu6epmtl-1">Setup for IPU6EPMTL</a></li>
-        <li><a href="#setup-for-ipu75xa-1">Setup for IPU75XA</a></li>
-        <li><a href="#setup-for-ipu8-1">Setup for IPU8</a></li>
-      </ul>
-    </li>
-    <li><a href="#camera-tuning-file-setup">Camera Tuning File Setup</a>
-      <ul>
-        <li><a href="#setup-for-ipu6epmtl-2">Setup for IPU6EPMTL</a></li>
-        <li><a href="#setup-for-ipu75xa-2">Setup for IPU75XA</a></li>
-        <li><a href="#setup-for-ipu8-2">Setup for IPU8</a></li>
-      </ul>
-    </li>
-    <li><a href="#environment-setup">Environment Setup</a></li>
-    <li><a href="#sensor-verification">Sensor Verification</a></li>
-    <li><a href="#sample-userspace-command">Sample Userspace Command</a></li>
-    <li><a href="#streaming-result">Streaming Result</a></li>
-  </ol>
-</details>
+## Table of Contents
+
+- [Hardware Connection](#hardware-connection)
+  - [MAX9296 (REV B) Connection](#max9296-rev-b-connection)
+  - [MAX96724 AIC (REV A) Connection](#max96724-aic-rev-a-connection)
+  - [MAX96724 AIC (D-PHY) (REV B) Connection](#max96724-aic-d-phy-rev-b-connection)
+  - [MAX96724 AIC (C-PHY) (REV B) Connection](#max96724-aic-c-phy-rev-b-connection)
+  - [MAX96724 AIC (C-PHY to D-PHY Adapter) (REV B) Connection](#max96724-aic-c-phy-to-d-phy-adapter-rev-b-connection)
+- [BIOS Configuration Table](#bios-configuration-table)
+  - [Disable C States](#disable-c-states)
+- [MIPI Camera Configuration](#mipi-camera-configuration)
+  - [Setup for IPU6EPMTL](#setup-for-ipu6epmtl)
+  - [Setup for IPU75XA](#setup-for-ipu75xa)
+  - [Setup for IPU8](#setup-for-ipu8)
+- [Camera Configuration File Setup](#camera-configuration-file-setup)
+  - [Setup for IPU6EPMTL](#setup-for-ipu6epmtl-1)
+  - [Setup for IPU75XA](#setup-for-ipu75xa-1)
+  - [Setup for IPU8](#setup-for-ipu8-1)
+- [Camera Tuning File Setup](#camera-tuning-file-setup)
+  - [Setup for IPU6EPMTL](#setup-for-ipu6epmtl-2)
+  - [Setup for IPU75XA](#setup-for-ipu75xa-2)
+  - [Setup for IPU8](#setup-for-ipu8-2)
+- [Environment Setup](#environment-setup)
+- [Sensor Verification](#sensor-verification)
+- [Sample Userspace Command](#sample-userspace-command)
+  - [Sensor Device Selection](#sensor-device-selection)
+    - [How to relate Sensor Number N with AIC Link Port](#how-to-relate-sensor-number-n-with-aic-link-port)
+  - [Frame Buffer Memory Type (IO Mode) Selection](#frame-buffer-memory-type-io-mode-selection)
+  - [Sensor Resolution Selection](#sensor-resolution-selection)
+  - [Sensor Format Selection](#sensor-format-selection)
+  - [Multi-Stream Selection](#multi-stream-selection)
+    - [Multiprocessing Multi-Stream](#multiprocessing-multi-stream)
+    - [Multithreading Multi-Stream](#multithreading-multi-stream)
+- [Streaming Result](#streaming-result)
 
 ## Hardware Connection
 
@@ -245,17 +234,39 @@ Upon setup completion, verify sensor with:
 |---|---|
 | 1 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-1 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
 | 2 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-2 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
+| N | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-N printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
 
 > **Note**: Refer to icamerasrc device-name property for more sensor details.
 
-##### How to relate Sensor Number with AIC Link Port
+##### How to relate Sensor Number N with AIC Link Port
 
-Refer to MAX9296 or MAX96724 AIC under [Hardware Connection](#hardware-connection), select the correct sensor number based on the physical AIC link port layout.
+<details>
+<summary>Sensor Number N For MAX9296 AIC</summary>
 
-| AIC Link Port | Sensor Number |
-|---            |---            |
-| A             | 1             |
-| B             | 2             |
+| Link Port | Sensor Number |
+|---|---|
+| A | 1 |
+| B | 2 |
+| C | 3 |
+| D | 4 |
+
+</details>
+
+<details>
+<summary>Sensor Number N For MAX96724 AIC</summary>
+
+| Link Port | Sensor Number |
+|---|---|
+| A | 1 |
+| B | 2 |
+| C | 3 |
+| D | 4 |
+| E | 5 |
+| F | 6 |
+| G | 7 |
+| H | 8 |
+
+</details>
 
 #### Frame Buffer Memory Type (IO Mode) Selection
 
@@ -278,12 +289,34 @@ Refer to MAX9296 or MAX96724 AIC under [Hardware Connection](#hardware-connectio
 |---|---|
 | NV12 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-1 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
 
-#### Number of Stream (Single Stream / Multi Stream) Selection
+#### Multi-Stream Selection
 
-| Number of Stream | Command Pipeline |
+Multi-stream support can be configured using either of the following approaches:
+
+- Multiprocessing
+- Multithreading
+
+##### Multiprocessing Multi-Stream
+
+To stream N sensors concurrently, launch N terminal windows.
+In each terminal, run the command below with the corresponding sensor number.
+
+| Number of Streams | Command Pipeline |
+|---|---|
+| xN | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-N printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
+
+##### Multithreading Multi-Stream
+
+Open a terminal window and run the command below, replacing the sensor number as needed.
+
+| Number of Streams | Command Pipeline |
 |---|---|
 | x1 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=1 scene-mode=normal device-name=ar0234_acpi-1 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
 | x2 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=2 scene-mode=normal device-name=ar0234_acpi-1 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false icamerasrc num-buffers=-1 num-vc=2 scene-mode=normal device-name=ar0234_acpi-2 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
+| x4 | gst-launch-1.0 icamerasrc num-buffers=-1 num-vc=4 scene-mode=normal device-name=ar0234_acpi-1 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false icamerasrc num-buffers=-1 num-vc=4 scene-mode=normal device-name=ar0234_acpi-2 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false icamerasrc num-buffers=-1 num-vc=4 scene-mode=normal device-name=ar0234_acpi-3 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false icamerasrc num-buffers=-1 num-vc=4 scene-mode=normal device-name=ar0234_acpi-4 printfps=true io-mode=dma_mode ! 'video/x-raw(memory:DMABuf),drm-format=NV12,width=1280,height=960' ! glimagesink sync=false |
+
+> **Note**: Known VC limitation (max vc=5) for multi-stream. \
+For example, to enable 8 streams, user can launch 2 terminals, with each terminal running x4 streams.
 
 ## Streaming Result
 
@@ -293,6 +326,10 @@ Refer to MAX9296 or MAX96724 AIC under [Hardware Connection](#hardware-connectio
 | x1               | DMA MODE | 30         |
 | x2               | USERPTR  | 30         |
 | x2               | DMA MODE | 30         |
+| x4               | USERPTR  | 30         |
+| x4               | DMA MODE | 30         |
+| x8               | USERPTR  | 30         |
+| x8               | DMA MODE | 30         |
 
 > **Note:** Please ensure your system enable support for specified number of stream before test.
 

--- a/doc/ov13b10/userspace-mipi.md
+++ b/doc/ov13b10/userspace-mipi.md
@@ -59,7 +59,7 @@ Config path: `Intel Advanced Menu`->`System Agent (SA) Configuration`->`MIPI Cam
 | EEPROM Type                | ROM_EEPROM_BRCA016GWZ| ROM_EEPROM_BRCA016GWZ|
 | VCM Type                   | VCM_DW9714           | VCM_DW9714           |
 | Number of I2C Components   | 7                    | 7                    |
-| I2C Channel                | I2C1                 | I2C0                 |
+| I2C Channel                | I2C1                 | I2C2                 |
 | Device 0                   |                      |                      |
 | I2C Address                | 10                   | 10                   |
 | Device Type                | Sensor               | Sensor               |

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -756,10 +756,9 @@ sensor_validate_format_size() {
 sensor_validate_fps() {
     local model=$1 cam=$2 stream=$3 sid=$4 fmt=$5 size=$6
     local requested_fps=$7 active_fps=$8 context=$9 dev codes line code name
-    local interval_args intervals candidate selected_fps supported=0
+    local interval_args intervals candidate selected_fps max_fps supported=0
 
     selected_fps=${requested_fps:-$active_fps}
-    [ -n "$requested_fps" ] || { echo "$selected_fps"; return; }
     sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
     dev=$(media-ctl -e "$SENSOR_ENTITY" 2>/dev/null) || {
         echo "$selected_fps"
@@ -782,22 +781,26 @@ sensor_validate_fps() {
     interval_args+=",width=${size%x*},height=${size#*x}"
     intervals=$(v4l2-ctl -d "$dev" --list-subdev-frameintervals \
         "$interval_args" 2>/dev/null) || intervals=""
+    [ -n "$intervals" ] || { echo "$selected_fps"; return; }
     while IFS= read -r line; do
         if [[ $line =~ \(([0-9.]+)[[:space:]]fps\) ]]; then
             candidate=${BASH_REMATCH[1]}
-            awk -v a="$candidate" -v b="$requested_fps" \
+            if [ -z "$max_fps" ] || awk -v a="$candidate" -v b="$max_fps" \
+                'BEGIN { exit !(a > b) }'; then
+                max_fps=$candidate
+            fi
+            awk -v a="$candidate" -v b="$selected_fps" \
                 'BEGIN { exit !((a - b < 0.0005) && (b - a < 0.0005)) }' && {
                 selected_fps=$candidate
                 supported=1
-                break
             }
         fi
     done <<<"$intervals"
-    if (( ! supported )); then
+    if (( ! supported )) && [ -n "$max_fps" ]; then
         printf "WARN: %s: FPS '%s' is unsupported with %s/%s; " \
-            "$context" "$requested_fps" "$fmt" "$size" >&2
-        printf "retaining current active FPS '%s'\n" "$active_fps" >&2
-        selected_fps=$active_fps
+            "$context" "$selected_fps" "$fmt" "$size" >&2
+        printf "using largest supported FPS '%s'\n" "$max_fps" >&2
+        selected_fps=$max_fps
     fi
     echo "$selected_fps"
 }
@@ -1035,6 +1038,7 @@ fi
 declare -A CFG_STREAM_FMT=()
 declare -A CFG_STREAM_SIZE=()
 declare -A CFG_STREAM_FPS=()
+declare -A CFG_STREAM_FPS_APPLY=()
 for k in "${!CFG_LINKS[@]}"; do
     d=${CFG_DES[$k]}
     l=${CFG_LINKS[$k]}
@@ -1045,6 +1049,10 @@ for k in "${!CFG_LINKS[@]}"; do
         sid=${STREAM_NODE[$s]}
         requested_fmt=${CFG_STREAM_FORMAT["${k}_${s}"]:-${CFG_FORMAT[$k]}}
         requested_size=${CFG_STREAM_RES["${k}_${s}"]:-${CFG_RES[$k]}}
+        if [ -n "$requested_fmt" ] || [ -n "$requested_size" ] ||
+            [ -n "${CFG_STREAM_FPS_REQUEST["${k}_${s}"]}" ]; then
+            CFG_STREAM_FPS_APPLY["${k}_${s}"]=1
+        fi
         detected=$(sensor_active_format "$model" "$cam" "$s" "$sid") || \
             die "cannot read active format from ${model} sensor on" \
                 "DES${d} link ${l}, stream ${s}"
@@ -1252,7 +1260,7 @@ for k in "${!CFG_LINKS[@]}"; do
                 mc_v "\"ar0234 ${cam}\":0/${sid} [fmt:${fmt}/${size} field:none]"
                 ;;
         esac
-            if [ -n "${CFG_STREAM_FPS_REQUEST["${k}_${s}"]}" ]; then
+            if [ -n "${CFG_STREAM_FPS_APPLY["${k}_${s}"]:-}" ]; then
                 actual_fps=$(sensor_set_fps "$model" "$cam" "$s" "$sid" \
                     "${CFG_STREAM_FPS["${k}_${s}"]}" \
                     "DES${d} link ${l} stream ${s}") || \

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -595,6 +595,8 @@ print_topology() {
 # CLI:
 #     mc-setup.sh                                      # default per-model streams, all DES
 #     mc-setup.sh [des=D,]link=N[,stream=<csv>][,res=WxH][,format=MBUS_CODE] ...
+#     mc-setup.sh [des=D,]link=N,stream=[TOKEN,res=WxH,format=MBUS_CODE],\
+#                                      [TOKEN,res=WxH,format=MBUS_CODE] ...
 #
 # When des= is omitted, des=0 is assumed (matches the legacy single-DES CLI).
 #
@@ -705,6 +707,8 @@ declare -a CFG_LINKS=()
 declare -a CFG_STREAMS=()
 declare -a CFG_RES=()
 declare -a CFG_FORMAT=()
+declare -A CFG_STREAM_RES=()
+declare -A CFG_STREAM_FORMAT=()
 
 if [ "$#" -eq 0 ]; then
     # Default: program every discovered link with its model's default streams.
@@ -721,6 +725,49 @@ if [ "$#" -eq 0 ]; then
 else
     for arg in "$@"; do
         des=""; link=""; streams=""; res=""; format=""
+        declare -A arg_stream_res=()
+        declare -A arg_stream_format=()
+
+        # Parse bracketed per-stream settings before splitting the remaining
+        # link-level options on commas.
+        if [[ $arg == *",stream=["* ]]; then
+            stream_specs=${arg#*,stream=}
+            arg=${arg%%,stream=*}
+            while [ -n "$stream_specs" ]; do
+                if [[ $stream_specs =~ ^\[([^][]+)\](,(.*))?$ ]]; then
+                    stream_spec=${BASH_REMATCH[1]}
+                    stream_specs=${BASH_REMATCH[3]}
+                else
+                    die "invalid bracketed stream specification in '$stream_specs'"
+                fi
+
+                IFS=',' read -ra stream_parts <<<"$stream_spec"
+                s=${stream_parts[0]}
+                is_known_stream "$s" || die "unknown stream '$s' in '$stream_spec'"
+                [ -z "${arg_stream_res[$s]+x}" ] && \
+                    [ -z "${arg_stream_format[$s]+x}" ] && \
+                    [[ " $streams " != *" $s "* ]] \
+                    || die "stream '$s' specified more than once"
+                streams+="${streams:+ }$s"
+                for stream_kv in "${stream_parts[@]:1}"; do
+                    case "$stream_kv" in
+                        res=*)
+                            arg_stream_res[$s]=${stream_kv#res=}
+                            [[ ${arg_stream_res[$s]} =~ ^[0-9]+x[0-9]+$ ]] \
+                                || die "res must be WIDTHxHEIGHT (got '${arg_stream_res[$s]}')"
+                            ;;
+                        format=*)
+                            arg_stream_format[$s]=${stream_kv#format=}
+                            [[ ${arg_stream_format[$s]} =~ ^[[:alnum:]_]+$ ]] \
+                                || die "format must be a media-bus code" \
+                                    "(got '${arg_stream_format[$s]}')"
+                            ;;
+                        *) die "unrecognized stream option '$stream_kv' in '$stream_spec'" ;;
+                    esac
+                done
+            done
+        fi
+
         IFS=',' read -ra parts <<<"$arg"
         for kv in "${parts[@]}"; do
             case "$kv" in
@@ -765,6 +812,12 @@ else
         CFG_STREAMS+=("$streams")
         CFG_RES+=("$res")
         CFG_FORMAT+=("$format")
+        k=$((${#CFG_LINKS[@]} - 1))
+        for s in $streams; do
+            CFG_STREAM_RES["${k}_${s}"]=${arg_stream_res[$s]:-}
+            CFG_STREAM_FORMAT["${k}_${s}"]=${arg_stream_format[$s]:-}
+        done
+        unset arg_stream_res arg_stream_format
     done
     # Reject duplicate (des,link) entries.
     declare -A seen=()
@@ -787,16 +840,18 @@ for k in "${!CFG_LINKS[@]}"; do
     cam=${CAM_BA[$key]}
     for s in ${CFG_STREAMS[$k]}; do
         sid=${STREAM_NODE[$s]}
+        requested_fmt=${CFG_STREAM_FORMAT["${k}_${s}"]:-${CFG_FORMAT[$k]}}
+        requested_size=${CFG_STREAM_RES["${k}_${s}"]:-${CFG_RES[$k]}}
         detected_fmt=""
         detected_size=""
-        if [ -z "${CFG_FORMAT[$k]}" ] || [ -z "${CFG_RES[$k]}" ]; then
+        if [ -z "$requested_fmt" ] || [ -z "$requested_size" ]; then
             detected=$(sensor_active_format "$model" "$cam" "$s" "$sid") || \
                 die "cannot read active format from ${model} sensor on" \
                     "DES${d} link ${l}, stream ${s}"
             read -r detected_fmt detected_size <<<"$detected"
         fi
-        CFG_STREAM_FMT["${k}_${s}"]=${CFG_FORMAT[$k]:-$detected_fmt}
-        CFG_STREAM_SIZE["${k}_${s}"]=${CFG_RES[$k]:-$detected_size}
+        CFG_STREAM_FMT["${k}_${s}"]=${requested_fmt:-$detected_fmt}
+        CFG_STREAM_SIZE["${k}_${s}"]=${requested_size:-$detected_size}
     done
 done
 
@@ -852,7 +907,9 @@ for k in "${!CFG_LINKS[@]}"; do
     for s in ${CFG_STREAMS[$k]}; do
         csi2_pad=${CSI2_PAD["${k}_${s}"]}
         node=$(( CAPTURE_BASE[d] + csi2_pad ))
-        echo -e "\t\t Stream\t\t [${s}] --> \t/dev/video${node}"
+        printf "                 Stream          %-8s %-10s %-12s -->  /dev/video%s\n" \
+            "[${s}]" "${CFG_STREAM_SIZE["${k}_${s}"]}" \
+            "${CFG_STREAM_FMT["${k}_${s}"]}" "$node"
     done
 done
 

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -588,6 +588,7 @@ print_topology() {
             "$i" "${MIPI_PREFIX[$i]}" "${MIPI_BA[$i]}" \
             "${MIPI_CSI2[$i]}" "${MIPI_CAP[$i]}"
     done
+    echo ""
 }
 
 # -------- per-sensor media-ctl programming -----------------------------------
@@ -629,17 +630,23 @@ print_topology() {
 # Per-sensor stream lookups
 # =============================================================================
 
-# Query one sensor source pad and print "<mbus-code> <width>x<height>".
-sensor_active_format() {
-    local model=$1 cam=$2 stream=$3 sid=$4 entity pad output fmt size
+sensor_entity_pad() {
+    local model=$1 cam=$2 stream=$3 sid=$4
 
     case "$model" in
-        d4xx)  entity="D4XX ${stream} ${cam}"; pad=0 ;;
-        isx031) entity="isx031 ${cam}"; pad="0/${sid}" ;;
+        d4xx)   SENSOR_ENTITY="D4XX ${stream} ${cam}"; SENSOR_PAD=0; SENSOR_SID=0 ;;
+        isx031) SENSOR_ENTITY="isx031 ${cam}"; SENSOR_PAD=0; SENSOR_SID=$sid ;;
         *) return 1 ;;
     esac
+}
 
-    output=$(media-ctl --get-v4l2 "\"${entity}\":${pad}" 2>/dev/null) || return 1
+# Query one sensor source pad and print "<mbus-code> <width>x<height>".
+sensor_active_format() {
+    local model=$1 cam=$2 stream=$3 sid=$4 output fmt size
+
+    sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
+    output=$(media-ctl --get-v4l2 \
+        "\"${SENSOR_ENTITY}\":${SENSOR_PAD}/${SENSOR_SID}" 2>/dev/null) || return 1
     if [[ $output =~ fmt:([[:alnum:]_]+)/([0-9]+x[0-9]+) ]]; then
         fmt=${BASH_REMATCH[1]}
         size=${BASH_REMATCH[2]}
@@ -647,6 +654,89 @@ sensor_active_format() {
         return 0
     fi
     return 1
+}
+
+# Print the requested format/size after checking the sensor's advertised
+# format-resolution combinations. Retain the active value for unsupported
+# fields.
+sensor_validate_format_size() {
+    local model=$1 cam=$2 stream=$3 sid=$4 requested_fmt=$5 requested_size=$6
+    local active_fmt=$7 active_size=$8 context=$9 dev codes line code name
+    local selected_fmt selected_size selected_code sizes supported
+    local min_w min_h max_w max_h req_w req_h
+    local range_re
+
+    range_re='Size[[:space:]]Range:[[:space:]]([0-9]+)x([0-9]+)'
+    range_re+='[[:space:]]-[[:space:]]([0-9]+)x([0-9]+)'
+
+    selected_fmt=${requested_fmt:-$active_fmt}
+    selected_size=${requested_size:-$active_size}
+    sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
+    dev=$(media-ctl -e "$SENSOR_ENTITY" 2>/dev/null) || {
+        echo "$selected_fmt $selected_size"
+        return 0
+    }
+
+    codes=$(v4l2-ctl -d "$dev" --list-subdev-mbus-codes \
+        pad="$SENSOR_PAD",stream="$SENSOR_SID" 2>/dev/null) || {
+        echo "$selected_fmt $selected_size"
+        return 0
+    }
+    while IFS= read -r line; do
+        if [[ $line =~ (0x[[:xdigit:]]+):[[:space:]]+MEDIA_BUS_FMT_([[:alnum:]_]+) ]]; then
+            code=${BASH_REMATCH[1]}
+            name=${BASH_REMATCH[2]^^}
+            if [ "$name" = "${selected_fmt^^}" ]; then
+                selected_code=$code
+                selected_fmt=$name
+            fi
+        fi
+    done <<<"$codes"
+
+    if [ -z "$selected_code" ]; then
+        [ -z "$requested_fmt" ] || printf \
+            "WARN: %s: format '%s' is unsupported; retaining current active format '%s'\n" \
+            "$context" "$requested_fmt" "$active_fmt" >&2
+        selected_fmt=$active_fmt
+        while IFS= read -r line; do
+            if [[ $line =~ (0x[[:xdigit:]]+):[[:space:]]+MEDIA_BUS_FMT_([[:alnum:]_]+) ]]; then
+                code=${BASH_REMATCH[1]}
+                name=${BASH_REMATCH[2]^^}
+                [ "$name" = "${active_fmt^^}" ] && selected_code=$code
+            fi
+        done <<<"$codes"
+    fi
+
+    if [ -n "$requested_size" ] && [ -n "$selected_code" ]; then
+        sizes=$(v4l2-ctl -d "$dev" --list-subdev-framesizes \
+            pad="$SENSOR_PAD",stream="$SENSOR_SID",code="$selected_code" 2>/dev/null) || sizes=""
+        supported=0
+        while IFS= read -r line; do
+            if [[ $line =~ $range_re ]]; then
+                min_w=${BASH_REMATCH[1]}; min_h=${BASH_REMATCH[2]}
+                max_w=${BASH_REMATCH[3]}; max_h=${BASH_REMATCH[4]}
+                req_w=${requested_size%x*}; req_h=${requested_size#*x}
+                if (( req_w >= min_w && req_w <= max_w && req_h >= min_h && req_h <= max_h )); then
+                    supported=1
+                    break
+                fi
+            elif [[ $line =~ Size:[[:space:]]Discrete[[:space:]]([0-9]+)x([0-9]+) ]]; then
+                req_w=${requested_size%x*}; req_h=${requested_size#*x}
+                if (( req_w == BASH_REMATCH[1] && req_h == BASH_REMATCH[2] )); then
+                    supported=1
+                    break
+                fi
+            fi
+        done <<<"$sizes"
+        if [ -n "$sizes" ] && (( ! supported )); then
+            printf "WARN: %s: resolution '%s' is unsupported with format '%s'; " \
+                "$context" "$requested_size" "$selected_fmt" >&2
+            printf "retaining current active resolution '%s'\n" "$active_size" >&2
+            selected_size=$active_size
+        fi
+    fi
+
+    echo "$selected_fmt $selected_size"
 }
 
 # Is stream token $1 declared as valid for model $2?
@@ -828,8 +918,8 @@ else
     done
 fi
 
-# Resolve each selected stream's format and size. A per-link CLI value wins;
-# otherwise preserve the active format currently reported by the sensor.
+# Resolve and validate each selected stream's format and size. Requested values
+# win when the sensor advertises support; otherwise retain its active settings.
 declare -A CFG_STREAM_FMT=()
 declare -A CFG_STREAM_SIZE=()
 for k in "${!CFG_LINKS[@]}"; do
@@ -842,16 +932,14 @@ for k in "${!CFG_LINKS[@]}"; do
         sid=${STREAM_NODE[$s]}
         requested_fmt=${CFG_STREAM_FORMAT["${k}_${s}"]:-${CFG_FORMAT[$k]}}
         requested_size=${CFG_STREAM_RES["${k}_${s}"]:-${CFG_RES[$k]}}
-        detected_fmt=""
-        detected_size=""
-        if [ -z "$requested_fmt" ] || [ -z "$requested_size" ]; then
-            detected=$(sensor_active_format "$model" "$cam" "$s" "$sid") || \
-                die "cannot read active format from ${model} sensor on" \
-                    "DES${d} link ${l}, stream ${s}"
-            read -r detected_fmt detected_size <<<"$detected"
-        fi
-        CFG_STREAM_FMT["${k}_${s}"]=${requested_fmt:-$detected_fmt}
-        CFG_STREAM_SIZE["${k}_${s}"]=${requested_size:-$detected_size}
+        detected=$(sensor_active_format "$model" "$cam" "$s" "$sid") || \
+            die "cannot read active format from ${model} sensor on" \
+                "DES${d} link ${l}, stream ${s}"
+        read -r detected_fmt detected_size <<<"$detected"
+        validated=$(sensor_validate_format_size "$model" "$cam" "$s" "$sid" \
+            "$requested_fmt" "$requested_size" "$detected_fmt" "$detected_size" \
+            "DES${d} link ${l} stream ${s}")
+        read -r CFG_STREAM_FMT["${k}_${s}"] CFG_STREAM_SIZE["${k}_${s}"] <<<"$validated"
     done
 done
 

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -1260,9 +1260,11 @@ for k in "${!CFG_LINKS[@]}"; do
                 mc_v "\"ar0234 ${cam}\":0/${sid} [fmt:${fmt}/${size} field:none]"
                 ;;
         esac
-            if [ -n "${CFG_STREAM_FPS_APPLY["${k}_${s}"]:-}" ]; then
+            fps=${CFG_STREAM_FPS["${k}_${s}"]}
+            if [ -n "${CFG_STREAM_FPS_APPLY["${k}_${s}"]:-}" ] &&
+                [[ $fps =~ ^[0-9]+([.][0-9]+)?$ ]]; then
                 actual_fps=$(sensor_set_fps "$model" "$cam" "$s" "$sid" \
-                    "${CFG_STREAM_FPS["${k}_${s}"]}" \
+                    "$fps" \
                     "DES${d} link ${l} stream ${s}") || \
                     die "cannot configure FPS on DES${d} link ${l}, stream ${s}"
                 CFG_STREAM_FPS["${k}_${s}"]=$actual_fps

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -50,30 +50,13 @@
 #   MAX_LINKS_max96724       Default: 4
 #   MAX_LINKS_max9296a       Default: 2
 #
-# D4XX default frame size (used for depth/rgb/ir when STREAM_SIZE_* unset):
-#   D4XX_WIDTH               Default: 640
-#   D4XX_HEIGHT              Default: 480
-#
-# Per-stream media-bus code overrides (STREAM_FMT_<token>):
-#   STREAM_FMT_depth         Default: UYVY8_1X16
-#   STREAM_FMT_rgb           Default: YUYV8_1X16
-#   STREAM_FMT_ir            Default: VYUY8_1X16
-#   STREAM_FMT_imu           Default: Y8_1X8
-#   STREAM_FMT_yuv           Default: UYVY8_1X16
-#
-# Per-stream frame size overrides (STREAM_SIZE_<token>):
-#   STREAM_SIZE_depth        Default: ${D4XX_WIDTH}x${D4XX_HEIGHT}
-#   STREAM_SIZE_rgb          Default: ${D4XX_WIDTH}x${D4XX_HEIGHT}
-#   STREAM_SIZE_ir           Default: ${D4XX_WIDTH}x${D4XX_HEIGHT}
-#   STREAM_SIZE_imu          Default: 38x1
-#   STREAM_SIZE_yuv          Default: 1920x1536
-#
 # IPU7 CSI2 RX source-pad cap:
 #   IPU_CSI2_SRC_PADS        Default: 16 (use 8 without the D4XX IPU7 patch).
 #
 # Example:
-#   DES_HID=INTC1139 D4XX_WIDTH=1280 D4XX_HEIGHT=720 \
-#       ./mc-setup.sh link=0,stream=depth,rgb link=1,stream=depth
+#   DES_HID=INTC1139 ./mc-setup.sh \
+#       link=0,stream=depth,res=1280x720,format=UYVY8_1X16 \
+#       link=1,stream=depth
 #
 # =============================================================================
 # USER CONFIGURATION
@@ -88,7 +71,7 @@
 #   3. List the model's stream tokens in MODEL_STREAMS and pick defaults in
 #      MODEL_DEFAULT_STREAMS.
 #   4. For each new stream token, set STREAM_NODE (and STREAM_MUXPAD if it
-#      flows through a d4xx-style mux), STREAM_FMT, STREAM_SIZE.
+#      flows through a d4xx-style mux).
 #   5. If your new media-bus code isn't covered, extend MBUS_TO_PIXFMT.
 #   6. If the sensor needs custom media-ctl wiring beyond a plain serializer
 #      pass-through (e.g. a mux subdev), extend the per-model case statements
@@ -167,29 +150,6 @@ declare -A STREAM_MUXPAD=(
     [rgb]=2
     [ir]=3
     [imu]=4
-)
-
-# ---- Per-stream media-bus format and frame size -----------------------------
-# Env-var overrides take precedence; use `STREAM_FMT_<token>` / `STREAM_SIZE_<token>`.
-D4XX_WIDTH=${D4XX_WIDTH:-640}
-D4XX_HEIGHT=${D4XX_HEIGHT:-480}
-D4XX_SIZE="${D4XX_WIDTH}x${D4XX_HEIGHT}"
-
-declare -A STREAM_FMT=(
-    [depth]=${STREAM_FMT_depth:-UYVY8_1X16}
-    [rgb]=${STREAM_FMT_rgb:-YUYV8_1X16}
-    [ir]=${STREAM_FMT_ir:-VYUY8_1X16}
-    [imu]=${STREAM_FMT_imu:-Y8_1X8}
-    [yuv]=${STREAM_FMT_yuv:-UYVY8_1X16}
-    [raw]=${STREAM_FMT_raw:-SGRBG10_1X10}
-)
-declare -A STREAM_SIZE=(
-    [depth]=${STREAM_SIZE_depth:-$D4XX_SIZE}
-    [rgb]=${STREAM_SIZE_rgb:-$D4XX_SIZE}
-    [ir]=${STREAM_SIZE_ir:-$D4XX_SIZE}
-    [imu]=${STREAM_SIZE_imu:-38x1}
-    [yuv]=${STREAM_SIZE_yuv:-1920x1536}
-    [raw]=${STREAM_SIZE_raw:-1280x960}
 )
 
 # ---- Media-bus -> V4L2 pixelformat fourcc (used on capture nodes) -----------
@@ -633,8 +593,8 @@ print_topology() {
 # -------- per-sensor media-ctl programming -----------------------------------
 #
 # CLI:
-#     mc-mixed.sh                                      # default per-model streams, all DES
-#     mc-mixed.sh [des=D,]link=N,stream=<csv> ...
+#     mc-setup.sh                                      # default per-model streams, all DES
+#     mc-setup.sh [des=D,]link=N[,stream=<csv>][,res=WxH][,format=MBUS_CODE] ...
 #
 # When des= is omitted, des=0 is assumed (matches the legacy single-DES CLI).
 #
@@ -642,7 +602,7 @@ print_topology() {
 #     d4xx:   depth | rgb | ir | imu
 #     isx031: yuv
 #
-# Default streams when no link is specified:
+# Default streams when no stream is specified for a link:
 #     d4xx   -> depth,rgb
 #     isx031 -> yuv
 # applied to every link discovered under every deserializer.
@@ -666,11 +626,26 @@ print_topology() {
 # =============================================================================
 # Per-sensor stream lookups
 # =============================================================================
-# Thin wrappers over the STREAM_FMT / STREAM_SIZE / MODEL_STREAMS tables
-# declared at the top of the file.
 
-stream_fmt()  { echo "${STREAM_FMT[$1]:-}"; }
-stream_size() { echo "${STREAM_SIZE[$1]:-}"; }
+# Query one sensor source pad and print "<mbus-code> <width>x<height>".
+sensor_active_format() {
+    local model=$1 cam=$2 stream=$3 sid=$4 entity pad output fmt size
+
+    case "$model" in
+        d4xx)  entity="D4XX ${stream} ${cam}"; pad=0 ;;
+        isx031) entity="isx031 ${cam}"; pad="0/${sid}" ;;
+        *) return 1 ;;
+    esac
+
+    output=$(media-ctl --get-v4l2 "\"${entity}\":${pad}" 2>/dev/null) || return 1
+    if [[ $output =~ fmt:([[:alnum:]_]+)/([0-9]+x[0-9]+) ]]; then
+        fmt=${BASH_REMATCH[1]}
+        size=${BASH_REMATCH[2]}
+        echo "$fmt $size"
+        return 0
+    fi
+    return 1
+}
 
 # Is stream token $1 declared as valid for model $2?
 stream_valid_for_model() {
@@ -728,6 +703,8 @@ print_topology
 declare -a CFG_DES=()
 declare -a CFG_LINKS=()
 declare -a CFG_STREAMS=()
+declare -a CFG_RES=()
+declare -a CFG_FORMAT=()
 
 if [ "$#" -eq 0 ]; then
     # Default: program every discovered link with its model's default streams.
@@ -737,17 +714,21 @@ if [ "$#" -eq 0 ]; then
             CFG_DES+=("$d")
             CFG_LINKS+=("$l")
             CFG_STREAMS+=("${MODEL_DEFAULT_STREAMS[${CAM_MODEL[$key]}]}")
+            CFG_RES+=("")
+            CFG_FORMAT+=("")
         done
     done
 else
     for arg in "$@"; do
-        des=""; link=""; streams=""
+        des=""; link=""; streams=""; res=""; format=""
         IFS=',' read -ra parts <<<"$arg"
         for kv in "${parts[@]}"; do
             case "$kv" in
                 des=*)    des=${kv#des=} ;;
                 link=*)   link=${kv#link=} ;;
                 stream=*) streams+="${streams:+ }${kv#stream=}" ;;
+                res=*)    res=${kv#res=} ;;
+                format=*) format=${kv#format=} ;;
                 *)
                     if is_known_stream "$kv"; then
                         streams+="${streams:+ }$kv"
@@ -758,8 +739,11 @@ else
             esac
         done
         [ -n "$link" ]    || die "missing link= in '$arg'"
-        [ -n "$streams" ] || die "missing stream= in '$arg'"
         [[ $link =~ ^[0-9]+$ ]] || die "link must be numeric (got '$link')"
+        [ -z "$res" ] || [[ $res =~ ^[0-9]+x[0-9]+$ ]] \
+            || die "res must be WIDTHxHEIGHT (got '$res')"
+        [ -z "$format" ] || [[ $format =~ ^[[:alnum:]_]+$ ]] \
+            || die "format must be a media-bus code (got '$format')"
         # Default des=0 when only one DES is present and des= was omitted.
         if [ -z "$des" ]; then
             if [ "$NUM_DES" -gt 1 ]; then
@@ -771,6 +755,7 @@ else
         (( des < NUM_DES )) || die "des=$des out of range (have ${NUM_DES} DES)"
         key="${des}_${link}"
         [ -n "${CAM_MODEL[$key]:-}" ] || die "no camera discovered on DES${des} link ${link}"
+        [ -n "$streams" ] || streams=${MODEL_DEFAULT_STREAMS[${CAM_MODEL[$key]}]}
         for s in $streams; do
             stream_valid_for_model "$s" "${CAM_MODEL[$key]}" \
                 || die "stream '$s' invalid for ${CAM_MODEL[$key]} on DES${des} link ${link}"
@@ -778,6 +763,8 @@ else
         CFG_DES+=("$des")
         CFG_LINKS+=("$link")
         CFG_STREAMS+=("$streams")
+        CFG_RES+=("$res")
+        CFG_FORMAT+=("$format")
     done
     # Reject duplicate (des,link) entries.
     declare -A seen=()
@@ -787,6 +774,31 @@ else
         seen[$sk]=1
     done
 fi
+
+# Resolve each selected stream's format and size. A per-link CLI value wins;
+# otherwise preserve the active format currently reported by the sensor.
+declare -A CFG_STREAM_FMT=()
+declare -A CFG_STREAM_SIZE=()
+for k in "${!CFG_LINKS[@]}"; do
+    d=${CFG_DES[$k]}
+    l=${CFG_LINKS[$k]}
+    key="${d}_${l}"
+    model=${CAM_MODEL[$key]}
+    cam=${CAM_BA[$key]}
+    for s in ${CFG_STREAMS[$k]}; do
+        sid=${STREAM_NODE[$s]}
+        detected_fmt=""
+        detected_size=""
+        if [ -z "${CFG_FORMAT[$k]}" ] || [ -z "${CFG_RES[$k]}" ]; then
+            detected=$(sensor_active_format "$model" "$cam" "$s" "$sid") || \
+                die "cannot read active format from ${model} sensor on" \
+                    "DES${d} link ${l}, stream ${s}"
+            read -r detected_fmt detected_size <<<"$detected"
+        fi
+        CFG_STREAM_FMT["${k}_${s}"]=${CFG_FORMAT[$k]:-$detected_fmt}
+        CFG_STREAM_SIZE["${k}_${s}"]=${CFG_RES[$k]:-$detected_size}
+    done
+done
 
 # IPU7 CSI2 RX source-pad cap (16 with the D4XX patch, 8 otherwise).
 IPU_CSI2_SRC_PADS=${IPU_CSI2_SRC_PADS:-16}
@@ -953,8 +965,8 @@ for k in "${!CFG_LINKS[@]}"; do
         sid=${STREAM_NODE[$s]}
         csi2_pad=${CSI2_PAD["${k}_${s}"]}
         des_stream=${DES_STREAM["${k}_${s}"]}
-        fmt=$(stream_fmt "$s")
-        size=$(stream_size "$s")
+        fmt=${CFG_STREAM_FMT["${k}_${s}"]}
+        size=${CFG_STREAM_SIZE["${k}_${s}"]}
 
         case "$model" in
             d4xx)
@@ -982,9 +994,9 @@ for k in "${!CFG_LINKS[@]}"; do
     d=${CFG_DES[$k]}
     for s in ${CFG_STREAMS[$k]}; do
         node=$(( CAPTURE_BASE[d] + CSI2_PAD["${k}_${s}"] ))
-        pixfmt=$(mbus_to_pixfmt "$(stream_fmt "$s")")
+        pixfmt=$(mbus_to_pixfmt "${CFG_STREAM_FMT["${k}_${s}"]}")
         [ -z "$pixfmt" ] && continue
-        size=$(stream_size "$s")
+        size=${CFG_STREAM_SIZE["${k}_${s}"]}
         w=${size%x*}
         h=${size#*x}
         v4l2-ctl -d "/dev/video${node}" \

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -754,10 +754,35 @@ is_known_stream() { [ -n "${STREAM_NODE[$1]+x}" ]; }
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
+check_media_tools() {
+    local missing=() tool
+    for tool in media-ctl v4l2-ctl; do
+        command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+    done
+    [ "${#missing[@]}" -eq 0 ] && return 0
+
+    echo "Missing required command(s): ${missing[*]}; installing v4l-utils..." >&2
+    command -v apt-get >/dev/null 2>&1 \
+        || die "apt-get not found; install v4l-utils manually"
+
+    local apt=(apt-get)
+    if (( EUID != 0 )); then
+        command -v sudo >/dev/null 2>&1 \
+            || die "root privileges are required to install v4l-utils"
+        apt=(sudo apt-get)
+    fi
+    "${apt[@]}" install -y v4l-utils \
+        || die "failed to install v4l-utils"
+
+    for tool in media-ctl v4l2-ctl; do
+        command -v "$tool" >/dev/null 2>&1 \
+            || die "$tool is still unavailable after installing v4l-utils"
+    done
+}
+
 # Require media-ctl >= 1.30 (older releases lack the streams/routing API used here).
 check_media_ctl_version() {
     local required_major=1 required_minor=30
-    command -v media-ctl >/dev/null 2>&1 || die "media-ctl not found in PATH"
 
     local ver
     ver=$(media-ctl --version 2>/dev/null | awk '/^media-ctl[[:space:]]+[0-9]+\./ {print $2; exit}')
@@ -777,6 +802,7 @@ check_media_ctl_version() {
 
 # -------- main ----------------------------------------------------------------
 
+check_media_tools
 check_media_ctl_version
 discover || exit 1
 

--- a/script/acpi/mc-setup.sh
+++ b/script/acpi/mc-setup.sh
@@ -596,8 +596,8 @@ print_topology() {
 # CLI:
 #     mc-setup.sh                                      # default per-model streams, all DES
 #     mc-setup.sh [des=D,]link=N[,stream=<csv>][,res=WxH][,format=MBUS_CODE] ...
-#     mc-setup.sh [des=D,]link=N,stream=[TOKEN,res=WxH,format=MBUS_CODE],\
-#                                      [TOKEN,res=WxH,format=MBUS_CODE] ...
+#     mc-setup.sh [des=D,]link=N,stream=[TOKEN,res=WxH,format=MBUS_CODE,fps=FPS],\
+#                                      [TOKEN,res=WxH,format=MBUS_CODE,fps=FPS] ...
 #
 # When des= is omitted, des=0 is assumed (matches the legacy single-DES CLI).
 #
@@ -651,6 +651,20 @@ sensor_active_format() {
         fmt=${BASH_REMATCH[1]}
         size=${BASH_REMATCH[2]}
         echo "$fmt $size"
+        return 0
+    fi
+    return 1
+}
+
+sensor_active_fps() {
+    local model=$1 cam=$2 stream=$3 sid=$4 dev output
+
+    sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
+    dev=$(media-ctl -e "$SENSOR_ENTITY" 2>/dev/null) || return 1
+    output=$(v4l2-ctl -d "$dev" --get-subdev-fps \
+        pad="$SENSOR_PAD",stream="$SENSOR_SID" 2>/dev/null) || return 1
+    if [[ $output =~ Frames[[:space:]]per[[:space:]]second:[[:space:]]([0-9.]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
         return 0
     fi
     return 1
@@ -739,6 +753,70 @@ sensor_validate_format_size() {
     echo "$selected_fmt $selected_size"
 }
 
+sensor_validate_fps() {
+    local model=$1 cam=$2 stream=$3 sid=$4 fmt=$5 size=$6
+    local requested_fps=$7 active_fps=$8 context=$9 dev codes line code name
+    local interval_args intervals candidate selected_fps supported=0
+
+    selected_fps=${requested_fps:-$active_fps}
+    [ -n "$requested_fps" ] || { echo "$selected_fps"; return; }
+    sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
+    dev=$(media-ctl -e "$SENSOR_ENTITY" 2>/dev/null) || {
+        echo "$selected_fps"
+        return
+    }
+    codes=$(v4l2-ctl -d "$dev" --list-subdev-mbus-codes \
+        pad="$SENSOR_PAD",stream="$SENSOR_SID" 2>/dev/null) || {
+        echo "$selected_fps"
+        return
+    }
+    while IFS= read -r line; do
+        if [[ $line =~ (0x[[:xdigit:]]+):[[:space:]]+MEDIA_BUS_FMT_([[:alnum:]_]+) ]]; then
+            name=${BASH_REMATCH[2]^^}
+            [ "$name" = "${fmt^^}" ] && code=${BASH_REMATCH[1]}
+        fi
+    done <<<"$codes"
+    [ -n "$code" ] || { echo "$selected_fps"; return; }
+
+    interval_args="pad=${SENSOR_PAD},stream=${SENSOR_SID},code=${code}"
+    interval_args+=",width=${size%x*},height=${size#*x}"
+    intervals=$(v4l2-ctl -d "$dev" --list-subdev-frameintervals \
+        "$interval_args" 2>/dev/null) || intervals=""
+    while IFS= read -r line; do
+        if [[ $line =~ \(([0-9.]+)[[:space:]]fps\) ]]; then
+            candidate=${BASH_REMATCH[1]}
+            awk -v a="$candidate" -v b="$requested_fps" \
+                'BEGIN { exit !((a - b < 0.0005) && (b - a < 0.0005)) }' && {
+                selected_fps=$candidate
+                supported=1
+                break
+            }
+        fi
+    done <<<"$intervals"
+    if (( ! supported )); then
+        printf "WARN: %s: FPS '%s' is unsupported with %s/%s; " \
+            "$context" "$requested_fps" "$fmt" "$size" >&2
+        printf "retaining current active FPS '%s'\n" "$active_fps" >&2
+        selected_fps=$active_fps
+    fi
+    echo "$selected_fps"
+}
+
+sensor_set_fps() {
+    local model=$1 cam=$2 stream=$3 sid=$4 fps=$5 context=$6 dev output
+
+    sensor_entity_pad "$model" "$cam" "$stream" "$sid" || return 1
+    dev=$(media-ctl -e "$SENSOR_ENTITY" 2>/dev/null) || return 1
+    v4l2-ctl -d "$dev" --set-subdev-fps \
+        pad="$SENSOR_PAD",stream="$SENSOR_SID",fps="$fps" >/dev/null \
+        || { echo "WARN: ${context}: failed to set FPS '${fps}'" >&2; return 1; }
+    output=$(v4l2-ctl -d "$dev" --get-subdev-fps \
+        pad="$SENSOR_PAD",stream="$SENSOR_SID" 2>/dev/null) || return 1
+    [[ $output =~ Frames[[:space:]]per[[:space:]]second:[[:space:]]([0-9.]+) ]] \
+        || return 1
+    echo "${BASH_REMATCH[1]}"
+}
+
 # Is stream token $1 declared as valid for model $2?
 stream_valid_for_model() {
     local s=$1 model=$2 t
@@ -825,6 +903,7 @@ declare -a CFG_RES=()
 declare -a CFG_FORMAT=()
 declare -A CFG_STREAM_RES=()
 declare -A CFG_STREAM_FORMAT=()
+declare -A CFG_STREAM_FPS_REQUEST=()
 
 if [ "$#" -eq 0 ]; then
     # Default: program every discovered link with its model's default streams.
@@ -843,6 +922,7 @@ else
         des=""; link=""; streams=""; res=""; format=""
         declare -A arg_stream_res=()
         declare -A arg_stream_format=()
+        declare -A arg_stream_fps=()
 
         # Parse bracketed per-stream settings before splitting the remaining
         # link-level options on commas.
@@ -877,6 +957,11 @@ else
                             [[ ${arg_stream_format[$s]} =~ ^[[:alnum:]_]+$ ]] \
                                 || die "format must be a media-bus code" \
                                     "(got '${arg_stream_format[$s]}')"
+                            ;;
+                        fps=*)
+                            arg_stream_fps[$s]=${stream_kv#fps=}
+                            [[ ${arg_stream_fps[$s]} =~ ^[0-9]+([.][0-9]+)?$ ]] \
+                                || die "fps must be numeric (got '${arg_stream_fps[$s]}')"
                             ;;
                         *) die "unrecognized stream option '$stream_kv' in '$stream_spec'" ;;
                     esac
@@ -932,8 +1017,9 @@ else
         for s in $streams; do
             CFG_STREAM_RES["${k}_${s}"]=${arg_stream_res[$s]:-}
             CFG_STREAM_FORMAT["${k}_${s}"]=${arg_stream_format[$s]:-}
+            CFG_STREAM_FPS_REQUEST["${k}_${s}"]=${arg_stream_fps[$s]:-}
         done
-        unset arg_stream_res arg_stream_format
+        unset arg_stream_res arg_stream_format arg_stream_fps
     done
     # Reject duplicate (des,link) entries.
     declare -A seen=()
@@ -948,6 +1034,7 @@ fi
 # win when the sensor advertises support; otherwise retain its active settings.
 declare -A CFG_STREAM_FMT=()
 declare -A CFG_STREAM_SIZE=()
+declare -A CFG_STREAM_FPS=()
 for k in "${!CFG_LINKS[@]}"; do
     d=${CFG_DES[$k]}
     l=${CFG_LINKS[$k]}
@@ -966,6 +1053,20 @@ for k in "${!CFG_LINKS[@]}"; do
             "$requested_fmt" "$requested_size" "$detected_fmt" "$detected_size" \
             "DES${d} link ${l} stream ${s}")
         read -r CFG_STREAM_FMT["${k}_${s}"] CFG_STREAM_SIZE["${k}_${s}"] <<<"$validated"
+        active_fps=$(sensor_active_fps "$model" "$cam" "$s" "$sid") || active_fps=""
+        if [ -n "$active_fps" ]; then
+            CFG_STREAM_FPS["${k}_${s}"]=$(sensor_validate_fps \
+                "$model" "$cam" "$s" "$sid" \
+                "${CFG_STREAM_FMT["${k}_${s}"]}" \
+                "${CFG_STREAM_SIZE["${k}_${s}"]}" \
+                "${CFG_STREAM_FPS_REQUEST["${k}_${s}"]}" "$active_fps" \
+                "DES${d} link ${l} stream ${s}")
+        else
+            [ -z "${CFG_STREAM_FPS_REQUEST["${k}_${s}"]}" ] || \
+                echo "WARN: DES${d} link ${l} stream ${s}: FPS control unavailable" >&2
+            CFG_STREAM_FPS["${k}_${s}"]="n/a"
+            CFG_STREAM_FPS_REQUEST["${k}_${s}"]=""
+        fi
     done
 done
 
@@ -1021,9 +1122,10 @@ for k in "${!CFG_LINKS[@]}"; do
     for s in ${CFG_STREAMS[$k]}; do
         csi2_pad=${CSI2_PAD["${k}_${s}"]}
         node=$(( CAPTURE_BASE[d] + csi2_pad ))
-        printf "                 Stream          %-8s %-10s %-12s -->  /dev/video%s\n" \
+        printf "                 Stream          %-8s %-10s %-12s %7s FPS -->  /dev/video%s\n" \
             "[${s}]" "${CFG_STREAM_SIZE["${k}_${s}"]}" \
-            "${CFG_STREAM_FMT["${k}_${s}"]}" "$node"
+            "${CFG_STREAM_FMT["${k}_${s}"]}" \
+            "${CFG_STREAM_FPS["${k}_${s}"]}" "$node"
     done
 done
 
@@ -1150,6 +1252,13 @@ for k in "${!CFG_LINKS[@]}"; do
                 mc_v "\"ar0234 ${cam}\":0/${sid} [fmt:${fmt}/${size} field:none]"
                 ;;
         esac
+            if [ -n "${CFG_STREAM_FPS_REQUEST["${k}_${s}"]}" ]; then
+                actual_fps=$(sensor_set_fps "$model" "$cam" "$s" "$sid" \
+                    "${CFG_STREAM_FPS["${k}_${s}"]}" \
+                    "DES${d} link ${l} stream ${s}") || \
+                    die "cannot configure FPS on DES${d} link ${l}, stream ${s}"
+                CFG_STREAM_FPS["${k}_${s}"]=$actual_fps
+            fi
         mc_v "\"${ser_pfx} ${ser}\":0/${sid} [fmt:${fmt}/${size} field:none]"
         mc_v "\"${ser_pfx} ${ser}\":1/${sid} [fmt:${fmt}/${size} field:none]"
         mc_v "\"${DES_PREFIX_NAME[$d]} ${DES_BA[$d]}\":${l}/${sid} [fmt:${fmt}/${size} field:none]"


### PR DESCRIPTION
### Description of changes

- Enhance mc-setup.sh with per-stream resolution, format, and FPS configuration.
- Validate settings against driver-supported values and correct unsupported FPS values.
- Check and install required media-ctl and v4l2-ctl tools.
- Correct the OV13B10 I2C channel documentation.
- Expand IPU7 D3 AR0234 support from two to eight GMSL cameras.
- Add matching IPU75XA sensor configuration entries and I2C addresses.
- Document multiprocessing and multistream usage for the 8-camera setup.