### PR TITLE
ipu7/acpi + dkms: make ISX031 link frequency configurable and fix RT kernel version parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ MODSRC := $(shell pwd)
 subdir-ccflags-y += -DDRIVER_VERSION_SUFFIX=\"${DRIVER_VERSION_SUFFIX}\"
 
 # Extract kernel version components - strip suffix like "-intel"
-KERNEL_VERSION := $(shell echo $(KERNELRELEASE) | cut -d. -f1)
-KERNEL_PATCHLEVEL := $(shell echo $(KERNELRELEASE) | cut -d. -f2 | cut -d- -f1)
+KERNEL_VERSION := $(shell echo $(KERNELRELEASE) | sed -E 's/^([0-9]+).*/\1/')
+KERNEL_PATCHLEVEL := $(shell echo $(KERNELRELEASE) | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
 
 # Check if kernel version is 6.18
 KERNEL_EQ_6_18 := $(shell ([ $(KERNEL_VERSION) -eq 6 ] && [ $(KERNEL_PATCHLEVEL) -eq 18 ]) && echo 1 || echo 0)

--- a/acpi/ipu7/_des_common_max96724.asl
+++ b/acpi/ipu7/_des_common_max96724.asl
@@ -15,7 +15,14 @@
  *   DES_PIPE_STR_AUTOSELECT - MAX96724 specific property
  *   DES_FSIN_GPIO_PIN      - (Optional) DES GPIO pin number, used in GpioIo (e.g. 7 for MFP7 on MAX96724,
  *                            used to receive the external GMSL frame sync trigger pulse)
+ *   LINK_FREQ              - Optional link frequency; defaults to 1 GHz
  */
+
+#ifndef LINK_FREQ
+#define LINK_FREQ_VAL 1000000000
+#else
+#define LINK_FREQ_VAL LINK_FREQ
+#endif
 
 Name (_UID, Zero)               // _UID: Unique ID
 
@@ -193,7 +200,7 @@ Name (PRT4, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ_VAL } }, // 1 GHz to be used by Intel IPU driver as link frequency
     },
 })
 
@@ -208,7 +215,7 @@ Name (PRT5, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ_VAL } }, // 1 GHz to be used by Intel IPU driver as link frequency
     },
 })
 
@@ -223,7 +230,7 @@ Name (PRT6, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ_VAL } }, // 1 GHz to be used by Intel IPU driver as link frequency
     },
 })
 
@@ -238,6 +245,8 @@ Name (PRT7, Package()
         #else
         Package () { "mipi-img-data-lanes", Package() { 1, 2 } },             // 2 lanes for CPHY/DPHY on Intel MIPI CRD
         #endif
-        Package () { "mipi-img-link-frequencies", Package() { 1000000000 } }, // 1 GHz to be used by Intel IPU driver as link frequency
+        Package () { "mipi-img-link-frequencies", Package() { LINK_FREQ_VAL } }, // 1 GHz to be used by Intel IPU driver as link frequency
     },
 })
+
+#undef LINK_FREQ_VAL

--- a/acpi/ipu7/max96724_d3_isx031.asl
+++ b/acpi/ipu7/max96724_d3_isx031.asl
@@ -54,6 +54,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C1"
             #define DES_PATH "\\_SB.PC00.DES0"
             #define DES_REF \_SB.PC00.DES0
+            #define LINK_FREQ 1250000000
             #include "_des_common_max96724.asl"
 
             // Channel-level defines for Channel 0 (CH00)
@@ -165,6 +166,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
 
         Device (DES1)
@@ -183,6 +185,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #define DES_I2C_BUS "\\_SB.PC00.I2C2"
             #define DES_PATH "\\_SB.PC00.DES1"
             #define DES_REF \_SB.PC00.DES1
+            #define LINK_FREQ 1250000000
             #include "_des_common_max96724.asl"
 
             // Channel-level defines for Channel 0 (CH00)
@@ -294,6 +297,7 @@ DefinitionBlock ("", "SSDT", 2, "", "IMG_IPU", 0x20260513)
             #undef DES_I2C_BUS
             #undef DES_PATH
             #undef DES_REF
+            #undef LINK_FREQ
         }
     }
 }

--- a/dkms.conf
+++ b/dkms.conf
@@ -8,8 +8,8 @@ CLEAN="make KERNELRELEASE=$kernelver KERNEL_SRC=$kernel_source_dir clean"
 AUTOINSTALL="yes"
 
 BUILD_EXCLUSIVE_KERNEL="^(6\.(12|17|18)([-.+].*|[a-z].*)?|7\.0([-.+].*|[a-z].*)?)$"
-KERNEL_VER=$(echo $kernelver | cut -d. -f1)
-KERNEL_PATCH=$(echo $kernelver | cut -d. -f2 | cut -d- -f1)
+KERNEL_VER=$(echo "$kernelver" | sed -E 's/^([0-9]+).*/\1/')
+KERNEL_PATCH=$(echo "$kernelver" | sed -E 's/^[0-9]+\.([0-9]+).*/\1/')
 
 MODULE_PATH="drivers/media/i2c"
 MODULE_DEST="/kernel/drivers/media/i2c/"

--- a/script/dkms-kernel-source.sh
+++ b/script/dkms-kernel-source.sh
@@ -20,9 +20,14 @@ if [[ -z "${kernelver:-}" ]]; then
   kernelver="$(uname -r)"
 fi
 
-major=$(echo "$kernelver" | cut -d- -f1| cut -d. -f1)
-minor=$(echo "$kernelver" | cut -d- -f1| cut -d. -f2)
-patch=$(echo "$kernelver" | cut -d- -f1| cut -d. -f3)
+if [[ "$kernelver" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+    major="${BASH_REMATCH[1]}"
+    minor="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[4]:-0}"
+else
+    echo "dkms-kernel-source.sh: could not parse kernel version from '${kernelver}'" >&2
+    exit 1
+fi
 
 # Fail fast on an unparseable version rather than silently fetching linux-0.0*.
 if ! [[ "$major" =~ ^[0-9]+$ ]] || (( major < 1 )); then


### PR DESCRIPTION
### Description of changes
1. ACPI for IPU7 MAX96724:

- Added a configurable link frequency macro with a default fallback of 1 GHz when no value is provided.
- Wired link-frequency properties to use the macro value.
- Set ISX031 D3 MAX96724 platform instances to 1.25 GHz explicitly.

2. DKMS and build version parsing:
- Replaced fragile cut-based parsing with regex/sed-based extraction for kernel major/minor values.
- Updated DKMS helper script parsing to correctly handle kernels with RT/vendor suffixes and fail fast on malformed versions.